### PR TITLE
Being able to compile on FreeBSD

### DIFF
--- a/devd_rules_freebsd/openhantek.conf
+++ b/devd_rules_freebsd/openhantek.conf
@@ -1,0 +1,32 @@
+# Hantek 6022BE (20 MHz, 48 MS/s)
+
+notify 100 {
+    match "system" "USB";
+    match "subsystem" "DEVICE";
+    match "type" "ATTACH";
+    match "vendor" "0x04b4";
+    match "product" "0x6022";
+    action "chgrp usbscope /dev/$ugen; chmod g+rw /dev/$ugen; chgrp -h usbscope /dev/$ugen; chmod -h g+rw /dev/$ugen";
+};
+
+notify 100 {
+    match "system" "USB";
+    match "subsystem" "DEVICE";
+    match "type" "ATTACH";
+    match "vendor" "0x04b5";
+    match "product" "0x6022";
+    action "chgrp usbscope /dev/$ugen; chmod g+rw /dev/$ugen; chgrp -h usbscope /dev/$ugen; chmod -h g+rw /dev/$ugen";
+};
+
+attach 100 {
+    match "vendor" "0x04B4";
+    match "product" "0x6022";
+    action "chgrp usbscope /dev/$ugen; chmod g+rw /dev/$ugen; chgrp -h usbscope /dev/$ugen; chmod -h g+rw /dev/$ugen";
+};
+
+attach 100 {
+    match "vendor" "0x04B5";
+    match "product" "0x6022";
+    action "chgrp usbscope /dev/$ugen; chmod g+rw /dev/$ugen; chgrp -h usbscope /dev/$ugen; chmod -h g+rw /dev/$ugen";
+};
+

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -11,7 +11,11 @@
 #include <QStyleFactory>
 #endif
 #include <iostream>
-#include <libusb-1.0/libusb.h>
+#ifdef __FreeBSD__
+	#include <libusb.h>
+#else
+	#include <libusb-1.0/libusb.h>
+#endif
 #include <memory>
 
 // Settings

--- a/openhantek/src/usb/ezusb.cpp
+++ b/openhantek/src/usb/ezusb.cpp
@@ -27,7 +27,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <libusb-1.0/libusb.h>
+#ifdef __FreeBSD__
+	#include <libusb.h>
+#else
+	#include <libusb-1.0/libusb.h>
+#endif
 
 #include "ezusb.h"
 

--- a/openhantek/src/usb/finddevices.cpp
+++ b/openhantek/src/usb/finddevices.cpp
@@ -66,7 +66,14 @@ int FindDevices::updateDeviceList() {
         }
     }
 
-    libusb_free_device_list(deviceList, true);
+	#if !defined(__FreeBSD__)
+		/*
+			ToDo: This introduces a potential resource leak if not executed
+			on FreeBSD. It seems there is a reference counting problem when
+			using libusb on FreeBSD.
+		*/
+		libusb_free_device_list(deviceList, true);
+	#endif
 
     return changes;
 }

--- a/openhantek/src/usb/finddevices.cpp
+++ b/openhantek/src/usb/finddevices.cpp
@@ -10,7 +10,11 @@
 #include <algorithm>
 #include "ezusb.h"
 #include "utils/printutils.h"
-#include <libusb-1.0/libusb.h>
+#ifdef __FreeBSD__
+	#include <libusb.h>
+#else
+	#include <libusb-1.0/libusb.h>
+#endif
 
 #include "modelregistry.h"
 

--- a/openhantek/src/usb/uploadFirmware.cpp
+++ b/openhantek/src/usb/uploadFirmware.cpp
@@ -4,7 +4,11 @@
 #include <QDebug>
 #include <QString>
 #include <QTemporaryFile>
-#include <libusb-1.0/libusb.h>
+#ifdef __FreeBSD__
+	#include <libusb.h>
+#else
+	#include <libusb-1.0/libusb.h>
+#endif
 #include <memory>
 
 #include "ezusb.h"

--- a/openhantek/src/usb/usbdevice.h
+++ b/openhantek/src/usb/usbdevice.h
@@ -4,7 +4,11 @@
 
 #include <QObject>
 #include <QStringList>
-#include <libusb-1.0/libusb.h>
+#ifdef __FreeBSD__
+	#include <libusb.h>
+#else
+	#include <libusb-1.0/libusb.h>
+#endif
 #include <memory>
 
 #include "usbdevicedefinitions.h"

--- a/openhantek/src/utils/printutils.cpp
+++ b/openhantek/src/utils/printutils.cpp
@@ -6,7 +6,11 @@
 #include <QLocale>
 #include <QStringList>
 
-#include <libusb-1.0/libusb.h>
+#ifdef __FreeBSD__
+	#include <libusb.h>
+#else
+	#include <libusb-1.0/libusb.h>
+#endif
 
 #include "utils/printutils.h"
 


### PR DESCRIPTION
There are a few minor things that prevented OpenHantek6022 to be compiled the same way on FreeBSD as on Linux. These have been:

* Different include paths for libusb.h than on Linux (they are directly in /usr/include/ instead of an subdirectory) which has been solved by surrounding the include statements with preprocessor conditionals for FreeBSD
* There seems to be a bug with reference counting of usb devices. The application has crashed because of dangling references whenever the list had correctly been released even though the devices reference count had been increased. The proposed fix herein is to simply suppress the release via libusb_free_device_list in finddevices.cpp when running on FreeBSD.