### PR TITLE
High dpi support

### DIFF
--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -11,8 +11,8 @@
 
 #include "dsowidget.h"
 
-#include "post/postprocessingsettings.h"
 #include "post/graphgenerator.h"
+#include "post/postprocessingsettings.h"
 #include "post/ppresult.h"
 
 #include "utils/printutils.h"
@@ -21,8 +21,8 @@
 #include "scopesettings.h"
 #include "viewconstants.h"
 #include "viewsettings.h"
-#include "widgets/levelslider.h"
 #include "widgets/datagrid.h"
+#include "widgets/levelslider.h"
 
 static int zoomScopeRow = 0;
 
@@ -105,7 +105,7 @@ DsoWidget::DsoWidget(DsoSettingsScope *scope, DsoSettingsView *view, const Dso::
     // The table for the measurements at screen bottom
     QPalette tablePalette = palette;
     measurementLayout = new QGridLayout();
-    int iii=0;
+    int iii = 0;
     measurementLayout->setColumnMinimumWidth(iii++, 50);
     measurementLayout->setColumnMinimumWidth(iii++, 30);
     measurementLayout->setColumnStretch(iii++, 3);
@@ -182,11 +182,11 @@ DsoWidget::DsoWidget(DsoSettingsScope *scope, DsoSettingsView *view, const Dso::
     }
     cursorDataGrid->selectItem(0);
 
-    connect(cursorDataGrid, &DataGrid::itemSelected, [this] (unsigned index) {
+    connect(cursorDataGrid, &DataGrid::itemSelected, [this](unsigned index) {
         mainScope->cursorSelected(index);
         zoomScope->cursorSelected(index);
     });
-    connect(cursorDataGrid, &DataGrid::itemUpdated, [this, scope] (unsigned index) {
+    connect(cursorDataGrid, &DataGrid::itemUpdated, [this, scope](unsigned index) {
         unsigned channelCount = scope->countChannels();
         if (0 < index && index < channelCount + 1) {
             ChannelID channel = index - 1;
@@ -276,12 +276,10 @@ DsoWidget::DsoWidget(DsoSettingsScope *scope, DsoSettingsView *view, const Dso::
     connect(mainSliders.voltageOffsetSlider, &LevelSlider::valueChanged, this, &DsoWidget::updateOffset);
     connect(zoomSliders.voltageOffsetSlider, &LevelSlider::valueChanged, this, &DsoWidget::updateOffset);
 
-    connect(mainSliders.triggerOffsetSlider, &LevelSlider::valueChanged, [this](int index, double value) {
-        updateTriggerOffset (index, value, true);
-    });
-    connect(zoomSliders.triggerOffsetSlider, &LevelSlider::valueChanged, [this](int index, double value) {
-        updateTriggerOffset (index, value, false);
-    });
+    connect(mainSliders.triggerOffsetSlider, &LevelSlider::valueChanged,
+            [this](int index, double value) { updateTriggerOffset(index, value, true); });
+    connect(zoomSliders.triggerOffsetSlider, &LevelSlider::valueChanged,
+            [this](int index, double value) { updateTriggerOffset(index, value, false); });
 
     connect(mainSliders.triggerLevelSlider, &LevelSlider::valueChanged, this, &DsoWidget::updateTriggerLevel);
     connect(zoomSliders.triggerLevelSlider, &LevelSlider::valueChanged, this, &DsoWidget::updateTriggerLevel);
@@ -317,9 +315,7 @@ void DsoWidget::updateCursorGrid(bool enabled) {
         }
         break;
     default:
-        if (cursorDataGrid->parent() != nullptr) {
-            cursorDataGrid->setParent(nullptr);
-        }
+        if (cursorDataGrid->parent() != nullptr) { cursorDataGrid->setParent(nullptr); }
         break;
     }
 }
@@ -337,11 +333,14 @@ void DsoWidget::setupSliders(DsoWidget::Sliders &sliders) {
     }
     for (ChannelID channel = 0; channel < scope->voltage.size(); ++channel) {
         sliders.voltageOffsetSlider->addSlider(scope->spectrum[channel].name, int(scope->voltage.size() + channel));
-        sliders.voltageOffsetSlider->setColor(unsigned( scope->voltage.size() ) + channel, view->screen.spectrum[channel]);
-        sliders.voltageOffsetSlider->setLimits(int( scope->voltage.size() + channel ), -DIVS_VOLTAGE / 2, DIVS_VOLTAGE / 2);
-        sliders.voltageOffsetSlider->setStep(int( scope->voltage.size() + channel ), 0.2);
-        sliders.voltageOffsetSlider->setValue(int( scope->voltage.size() + channel ), scope->spectrum[channel].offset);
-        sliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel, scope->spectrum[channel].used);
+        sliders.voltageOffsetSlider->setColor(unsigned(scope->voltage.size()) + channel,
+                                              view->screen.spectrum[channel]);
+        sliders.voltageOffsetSlider->setLimits(int(scope->voltage.size() + channel), -DIVS_VOLTAGE / 2,
+                                               DIVS_VOLTAGE / 2);
+        sliders.voltageOffsetSlider->setStep(int(scope->voltage.size() + channel), 0.2);
+        sliders.voltageOffsetSlider->setValue(int(scope->voltage.size() + channel), scope->spectrum[channel].offset);
+        sliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel,
+                                                     scope->spectrum[channel].used);
     }
 
     // The triggerPosition slider
@@ -349,17 +348,16 @@ void DsoWidget::setupSliders(DsoWidget::Sliders &sliders) {
     sliders.triggerOffsetSlider->addSlider();
     sliders.triggerOffsetSlider->setLimits(0, 0.0, 1.0);
     sliders.triggerOffsetSlider->setStep(0, 0.2 / double(DIVS_TIME));
-    sliders.triggerOffsetSlider->setValue(0, scope->trigger.offset );
+    sliders.triggerOffsetSlider->setValue(0, scope->trigger.offset);
     sliders.triggerOffsetSlider->setIndexVisible(0, true);
 
     // The sliders for the trigger levels
     sliders.triggerLevelSlider = new LevelSlider(Qt::LeftArrow);
     for (ChannelID channel = 0; channel < spec->channels; ++channel) {
         sliders.triggerLevelSlider->addSlider(int(channel));
-        sliders.triggerLevelSlider->setColor(channel,
-                                             (channel == scope->trigger.source)
-                                                 ? view->screen.voltage[channel]
-                                                 : view->screen.voltage[channel].darker());
+        sliders.triggerLevelSlider->setColor(channel, (channel == scope->trigger.source)
+                                                          ? view->screen.voltage[channel]
+                                                          : view->screen.voltage[channel].darker());
         adaptTriggerLevelSlider(sliders, channel);
         sliders.triggerLevelSlider->setValue(int(channel), scope->voltage[channel].trigger);
         sliders.triggerLevelSlider->setIndexVisible(channel, scope->voltage[channel].used);
@@ -378,14 +376,14 @@ void DsoWidget::setupSliders(DsoWidget::Sliders &sliders) {
 
 /// \brief Set the trigger level sliders minimum and maximum to the new values.
 void DsoWidget::adaptTriggerLevelSlider(DsoWidget::Sliders &sliders, ChannelID channel) {
-    //printf( "DW::adaptTriggerLevelSlider( %d )\n", channel );
+    // printf( "DW::adaptTriggerLevelSlider( %d )\n", channel );
     sliders.triggerLevelSlider->setLimits(int(channel),
                                           (-DIVS_VOLTAGE / 2 - scope->voltage[channel].offset) * scope->gain(channel),
-                                          ( DIVS_VOLTAGE / 2 - scope->voltage[channel].offset) * scope->gain(channel) );
+                                          (DIVS_VOLTAGE / 2 - scope->voltage[channel].offset) * scope->gain(channel));
     sliders.triggerLevelSlider->setStep(int(channel), scope->gain(channel) * 0.05);
     double value = sliders.triggerLevelSlider->value(int(channel));
-    if ( bool(value) ) { // ignore when first called at init
-//        updateTriggerLevel(channel, value);
+    if (bool(value)) { // ignore when first called at init
+                       //        updateTriggerLevel(channel, value);
     }
 }
 
@@ -419,17 +417,15 @@ void DsoWidget::setMeasurementVisible(ChannelID channel) {
     if (!scope->spectrum[channel].used) { measurementMagnitudeLabel[channel]->setText(QString()); }
 }
 
-
 /// \brief Update the label about the marker measurements
 void DsoWidget::updateMarkerDetails() {
     double m1 = scope->horizontal.cursor.pos[0].x() + DIVS_TIME / 2; // zero at center -> zero at left margin
     double m2 = scope->horizontal.cursor.pos[1].x() + DIVS_TIME / 2; // zero at center -> zero at left margin
-    if ( m1 > m2 )
-        std::swap( m1, m2 );
+    if (m1 > m2) std::swap(m1, m2);
     double divs = m2 - m1;
     // t = 0 at trigger position
-    double time0 = ( m1 - DIVS_TIME * scope->trigger.offset ) * scope->horizontal.timebase;
-    double time1 = ( m2 - DIVS_TIME * scope->trigger.offset ) * scope->horizontal.timebase;
+    double time0 = (m1 - DIVS_TIME * scope->trigger.offset) * scope->horizontal.timebase;
+    double time1 = (m2 - DIVS_TIME * scope->trigger.offset) * scope->horizontal.timebase;
     double time = divs * scope->horizontal.timebase;
     double freq0 = m1 * scope->horizontal.frequencybase;
     double freq1 = m2 * scope->horizontal.frequencybase;
@@ -438,20 +434,21 @@ void DsoWidget::updateMarkerDetails() {
     bool freqUsed = false;
 
     int index = 0;
-    cursorDataGrid->updateInfo( unsigned( index++ ), true, QString(),
-        valueToString(time, UNIT_SECONDS, 3), valueToString( freq, UNIT_HERTZ, 3 ) );
+    cursorDataGrid->updateInfo(unsigned(index++), true, QString(), valueToString(time, UNIT_SECONDS, 3),
+                               valueToString(freq, UNIT_HERTZ, 3));
 
     for (ChannelID channel = 0; channel < scope->voltage.size(); ++channel) {
         if (scope->voltage[channel].used) {
             timeUsed = true; // at least one voltage channel used -> show marker time details
             QPointF p0 = scope->voltage[channel].cursor.pos[0];
             QPointF p1 = scope->voltage[channel].cursor.pos[1];
-            cursorDataGrid->updateInfo( unsigned( index ), true,
+            cursorDataGrid->updateInfo(
+                unsigned(index), true,
                 scope->voltage[channel].cursor.shape != DsoSettingsScopeCursor::NONE ? tr("ON") : tr("OFF"),
                 valueToString(fabs(p1.x() - p0.x()) * scope->horizontal.timebase, UNIT_SECONDS, 4),
                 valueToString(fabs(p1.y() - p0.y()) * scope->gain(channel), UNIT_VOLTS, 4));
         } else {
-            cursorDataGrid->updateInfo( unsigned( index ), false );
+            cursorDataGrid->updateInfo(unsigned(index), false);
         }
         ++index;
     }
@@ -460,67 +457,64 @@ void DsoWidget::updateMarkerDetails() {
             freqUsed = true; // at least one spec channel used -> show marker freq details
             QPointF p0 = scope->spectrum[channel].cursor.pos[0];
             QPointF p1 = scope->spectrum[channel].cursor.pos[1];
-            cursorDataGrid->updateInfo( unsigned( index ), true,
+            cursorDataGrid->updateInfo(
+                unsigned(index), true,
                 scope->spectrum[channel].cursor.shape != DsoSettingsScopeCursor::NONE ? tr("ON") : tr("OFF"),
                 valueToString(fabs(p1.x() - p0.x()) * scope->horizontal.frequencybase, UNIT_HERTZ, 4),
                 valueToString(fabs(p1.y() - p0.y()) * scope->spectrum[channel].magnitude, UNIT_DECIBEL, 4));
         } else {
-            cursorDataGrid->updateInfo( unsigned( index ), false );
+            cursorDataGrid->updateInfo(unsigned(index), false);
         }
         ++index;
     }
 
-    if ( divs >= DIVS_TIME || ( m1 <= 0 && m2 <= 0) || ( m1 >= DIVS_TIME && m2 >= DIVS_TIME) ) {
+    if (divs >= DIVS_TIME || (m1 <= 0 && m2 <= 0) || (m1 >= DIVS_TIME && m2 >= DIVS_TIME)) {
         // markers at left/right margins -> don't display
-        markerInfoLabel->setVisible( false );
-        markerTimeLabel->setVisible( false );
-        markerFrequencyLabel->setVisible( false );
-        markerTimebaseLabel->setVisible( false );
-        markerFrequencybaseLabel->setVisible( false );
+        markerInfoLabel->setVisible(false);
+        markerTimeLabel->setVisible(false);
+        markerFrequencyLabel->setVisible(false);
+        markerTimebaseLabel->setVisible(false);
+        markerFrequencybaseLabel->setVisible(false);
     } else {
-        markerInfoLabel->setVisible( true );
-        markerTimeLabel->setVisible( true );
-        markerFrequencyLabel->setVisible( true );
-        markerTimebaseLabel->setVisible( view->zoom );
-        markerFrequencybaseLabel->setVisible( view->zoom );
-        QString mInfo( tr( "Markers  ") );
-        QString mTime( tr( "Time: ") );
-        QString mFreq( tr( "Frequency: ") );
+        markerInfoLabel->setVisible(true);
+        markerTimeLabel->setVisible(true);
+        markerFrequencyLabel->setVisible(true);
+        markerTimebaseLabel->setVisible(view->zoom);
+        markerFrequencybaseLabel->setVisible(view->zoom);
+        QString mInfo(tr("Markers  "));
+        QString mTime(tr("Time: "));
+        QString mFreq(tr("Frequency: "));
         if (view->zoom) {
-            if ( divs != 0.0 )
-                mInfo = tr( "Zoom x%L1  " ).arg( DIVS_TIME / divs, -1, 'g', 3 );
+            if (divs != 0.0)
+                mInfo = tr("Zoom x%L1  ").arg(DIVS_TIME / divs, -1, 'g', 3);
             else // avoid div by zero
-                mInfo = tr( "Zoom ---  " );
+                mInfo = tr("Zoom ---  ");
             mTime = " t: ";
             mFreq = " f: ";
-            markerTimebaseLabel->setText("  " + valueToString( time / DIVS_TIME, UNIT_SECONDS, 3 ) + tr("/div"));
-            markerTimebaseLabel->setVisible( timeUsed );
-            markerFrequencybaseLabel->setText( "  " + valueToString( freq / DIVS_TIME, UNIT_HERTZ, 3 ) + tr("/div"));
-            markerFrequencybaseLabel->setVisible( freqUsed );
+            markerTimebaseLabel->setText("  " + valueToString(time / DIVS_TIME, UNIT_SECONDS, 3) + tr("/div"));
+            markerTimebaseLabel->setVisible(timeUsed);
+            markerFrequencybaseLabel->setText("  " + valueToString(freq / DIVS_TIME, UNIT_HERTZ, 3) + tr("/div"));
+            markerFrequencybaseLabel->setVisible(freqUsed);
         }
-        markerInfoLabel->setText( mInfo );
-        if ( timeUsed ) {
-            mTime += QString( "%1" ).arg( valueToString( time0, UNIT_SECONDS, 3 ) );
-            if ( time > 0 )
-                mTime += QString( " ... %1,  Δt: %2 (%3) ")
-                    .arg( valueToString( time1, UNIT_SECONDS, 3 ),
-                          valueToString( time, UNIT_SECONDS, 3 ),
-                          valueToString( 1/time, UNIT_HERTZ, 3) )
-                ;
-            markerTimeLabel->setText( mTime );
+        markerInfoLabel->setText(mInfo);
+        if (timeUsed) {
+            mTime += QString("%1").arg(valueToString(time0, UNIT_SECONDS, 3));
+            if (time > 0)
+                mTime += QString(" ... %1,  Δt: %2 (%3) ")
+                             .arg(valueToString(time1, UNIT_SECONDS, 3), valueToString(time, UNIT_SECONDS, 3),
+                                  valueToString(1 / time, UNIT_HERTZ, 3));
+            markerTimeLabel->setText(mTime);
         } else {
-            markerTimeLabel->setText( "" );
+            markerTimeLabel->setText("");
         }
-        if ( freqUsed ) {
-             mFreq += QString( "%1" ).arg( valueToString( freq0, UNIT_HERTZ, 3 ) );
-            if ( freq > 0 )
-                mFreq += QString( " ... %2,  Δf: %3 " )
-                    .arg( valueToString( freq1, UNIT_HERTZ, 3 ),
-                          valueToString( freq, UNIT_HERTZ, 3 ) )
-                ;
-            markerFrequencyLabel->setText( mFreq );
+        if (freqUsed) {
+            mFreq += QString("%1").arg(valueToString(freq0, UNIT_HERTZ, 3));
+            if (freq > 0)
+                mFreq += QString(" ... %2,  Δf: %3 ")
+                             .arg(valueToString(freq1, UNIT_HERTZ, 3), valueToString(freq, UNIT_HERTZ, 3));
+            markerFrequencyLabel->setText(mFreq);
         } else
-            markerFrequencyLabel->setText( "" );
+            markerFrequencyLabel->setText("");
     }
 }
 
@@ -542,25 +536,23 @@ void DsoWidget::updateTriggerDetails() {
     tablePalette.setColor(QPalette::WindowText, view->screen.voltage[scope->trigger.source]);
     settingsTriggerLabel->setPalette(tablePalette);
     QString levelString = valueToString(scope->voltage[scope->trigger.source].trigger, UNIT_VOLTS, 3);
-    QString pretriggerString = tr("%L1%").arg( int( round(scope->trigger.offset * 100 ) ) );
+    QString pretriggerString = tr("%L1%").arg(int(round(scope->trigger.offset * 100)));
     QString pre = Dso::slopeString(scope->trigger.slope); // trigger slope
-    QString post = pre; // opposite trigger slope
-    if ( scope->trigger.slope == Dso::Slope::Positive )
-        post = Dso::slopeString( Dso::Slope:: Negative );
-    else if ( scope->trigger.slope == Dso::Slope::Negative )
-        post = Dso::slopeString( Dso::Slope:: Positive );
-    QString pulseWidthString = bool( pulseWidth1 ) ? pre + valueToString( pulseWidth1, UNIT_SECONDS, 3) + post : "";
-    pulseWidthString += bool( pulseWidth2 )? valueToString( pulseWidth2, UNIT_SECONDS, 3) + pre : "";
-    if ( bool( pulseWidth1 ) && bool( pulseWidth2 ) ) {
-        int dutyCyle = int( 0.5 + ( 100.0 * pulseWidth1 ) / (pulseWidth1 + pulseWidth2) );
-        pulseWidthString += " (" + QString::number( dutyCyle ) + "%)";
+    QString post = pre;                                   // opposite trigger slope
+    if (scope->trigger.slope == Dso::Slope::Positive)
+        post = Dso::slopeString(Dso::Slope::Negative);
+    else if (scope->trigger.slope == Dso::Slope::Negative)
+        post = Dso::slopeString(Dso::Slope::Positive);
+    QString pulseWidthString = bool(pulseWidth1) ? pre + valueToString(pulseWidth1, UNIT_SECONDS, 3) + post : "";
+    pulseWidthString += bool(pulseWidth2) ? valueToString(pulseWidth2, UNIT_SECONDS, 3) + pre : "";
+    if (bool(pulseWidth1) && bool(pulseWidth2)) {
+        int dutyCyle = int(0.5 + (100.0 * pulseWidth1) / (pulseWidth1 + pulseWidth2));
+        pulseWidthString += " (" + QString::number(dutyCyle) + "%)";
     }
-    settingsTriggerLabel->setText( tr( "%1  %2  %3  %4  %5" )
-                                      .arg( scope->voltage[scope->trigger.source].name,
-                                            Dso::slopeString(scope->trigger.slope),
-                                            levelString, pretriggerString, pulseWidthString
-                                          )
-                                 );
+    settingsTriggerLabel->setText(tr("%1  %2  %3  %4  %5")
+                                      .arg(scope->voltage[scope->trigger.source].name,
+                                           Dso::slopeString(scope->trigger.slope), levelString, pretriggerString,
+                                           pulseWidthString));
 }
 
 /// \brief Update the label about the trigger settings
@@ -586,8 +578,8 @@ void DsoWidget::updateFrequencybase(double frequencybase) {
 /// \param samplerate The samplerate set in the oscilloscope.
 void DsoWidget::updateSamplerate(double newSamplerate) {
     samplerate = newSamplerate;
-    dotsOnScreen = unsigned( samplerate * timebase * DIVS_TIME + 0.99 );
-    //printf( "DsoWidget::updateSamplerate( %g ) -> %d\n", samplerate, dotsOnScreen );
+    dotsOnScreen = unsigned(samplerate * timebase * DIVS_TIME + 0.99);
+    // printf( "DsoWidget::updateSamplerate( %g ) -> %d\n", samplerate, dotsOnScreen );
     settingsSamplerateLabel->setText(valueToString(samplerate, UNIT_SAMPLES, -1) + tr("/s"));
 }
 
@@ -595,8 +587,8 @@ void DsoWidget::updateSamplerate(double newSamplerate) {
 /// \param timebase The timebase used for displaying the trace.
 void DsoWidget::updateTimebase(double newTimebase) {
     timebase = newTimebase;
-    dotsOnScreen = unsigned( samplerate * timebase * DIVS_TIME + 0.99 );
-    //printf( "DsoWidget::updateTimebase( %g ) -> %d\n", timebase, dotsOnScreen );
+    dotsOnScreen = unsigned(samplerate * timebase * DIVS_TIME + 0.99);
+    // printf( "DsoWidget::updateTimebase( %g ) -> %d\n", timebase, dotsOnScreen );
     settingsTimebaseLabel->setText(valueToString(timebase, UNIT_SECONDS, -1) + tr("/div"));
     updateMarkerDetails();
 }
@@ -609,10 +601,10 @@ void DsoWidget::updateSpectrumMagnitude(ChannelID channel) { updateSpectrumDetai
 /// \param channel The channel whose used-state was changed.
 /// \param used The new used-state for the channel.
 void DsoWidget::updateSpectrumUsed(ChannelID channel, bool used) {
-    if (channel >= unsigned( scope->voltage.size() ) ) return;
+    if (channel >= unsigned(scope->voltage.size())) return;
 
-    mainSliders.voltageOffsetSlider->setIndexVisible( unsigned( scope->voltage.size() ) + channel, used );
-    zoomSliders.voltageOffsetSlider->setIndexVisible( unsigned( scope->voltage.size() ) + channel, used );
+    mainSliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel, used);
+    zoomSliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel, used);
 
     updateSpectrumDetails(channel);
     updateMarkerDetails();
@@ -631,9 +623,8 @@ void DsoWidget::updateTriggerSource() {
     zoomSliders.triggerOffsetSlider->setColor(0, view->screen.voltage[scope->trigger.source]);
 
     for (ChannelID channel = 0; channel < spec->channels; ++channel) {
-        QColor color = (channel == scope->trigger.source)
-                           ? view->screen.voltage[channel]
-                           : view->screen.voltage[channel].darker();
+        QColor color =
+            (channel == scope->trigger.source) ? view->screen.voltage[channel] : view->screen.voltage[channel].darker();
         mainSliders.triggerLevelSlider->setColor(channel, color);
         zoomSliders.triggerLevelSlider->setColor(channel, color);
     }
@@ -644,8 +635,7 @@ void DsoWidget::updateTriggerSource() {
 /// \brief Handles couplingChanged signal from the voltage dock.
 /// \param channel The channel whose coupling was changed.
 void DsoWidget::updateVoltageCoupling(ChannelID channel) {
-    if ( channel >= unsigned( scope->voltage.size() ) )
-        return;
+    if (channel >= unsigned(scope->voltage.size())) return;
     measurementMiscLabel[channel]->setText(Dso::couplingString(scope->coupling(channel, spec)));
 }
 
@@ -658,8 +648,7 @@ void DsoWidget::updateMathMode() {
 /// \brief Handles gainChanged signal from the voltage dock.
 /// \param channel The channel whose gain was changed.
 void DsoWidget::updateVoltageGain(ChannelID channel) {
-    if ( channel >= unsigned( scope->voltage.size() ) )
-        return;
+    if (channel >= unsigned(scope->voltage.size())) return;
     if (channel < spec->channels) {
         adaptTriggerLevelSlider(mainSliders, channel);
         adaptTriggerLevelSlider(zoomSliders, channel);
@@ -671,9 +660,9 @@ void DsoWidget::updateVoltageGain(ChannelID channel) {
 /// \param channel The channel whose used-state was changed.
 /// \param used The new used-state for the channel.
 void DsoWidget::updateVoltageUsed(ChannelID channel, bool used) {
-    if ( channel >= unsigned( scope->voltage.size() ) ) return;
+    if (channel >= unsigned(scope->voltage.size())) return;
 
-//    if (!used && cursorDataGrid->voltageCursors[channel].selector->isChecked()) cursorDataGrid->selectItem(0);
+    //    if (!used && cursorDataGrid->voltageCursors[channel].selector->isChecked()) cursorDataGrid->selectItem(0);
 
     mainSliders.voltageOffsetSlider->setIndexVisible(channel, used);
     zoomSliders.voltageOffsetSlider->setIndexVisible(channel, used);
@@ -688,7 +677,7 @@ void DsoWidget::updateVoltageUsed(ChannelID channel, bool used) {
 
 /// \brief Change the record length.
 void DsoWidget::updateRecordLength(unsigned long size) {
-    settingsSamplesOnScreen->setText(valueToString(size, UNIT_SAMPLES, -1) + tr(" on screen") );
+    settingsSamplesOnScreen->setText(valueToString(size, UNIT_SAMPLES, -1) + tr(" on screen"));
 }
 
 /// \brief Show/hide the zoom view.
@@ -727,39 +716,38 @@ void DsoWidget::showNew(std::shared_ptr<PPresult> analysedData) {
     swTriggerStatus->setPalette(triggerLabelPalette);
     swTriggerStatus->setVisible(true);
     updateRecordLength(dotsOnScreen);
-    pulseWidth1 = analysedData.get()->data( 0 )->pulseWidth1;
-    pulseWidth2 = analysedData.get()->data( 0 )->pulseWidth2;
+    pulseWidth1 = analysedData.get()->data(0)->pulseWidth1;
+    pulseWidth2 = analysedData.get()->data(0)->pulseWidth2;
     updateTriggerDetails();
     for (ChannelID channel = 0; channel < scope->voltage.size(); ++channel) {
         if (scope->voltage[channel].used && analysedData.get()->data(channel)) {
             // Vpp Amplitude string representation (3 significant digits)
-            measurementVppLabel[channel]->setText(
-                valueToString( analysedData.get()->data(channel)->vpp, UNIT_VOLTS, 3 ) + "pp" );
+            measurementVppLabel[channel]->setText(valueToString(analysedData.get()->data(channel)->vpp, UNIT_VOLTS, 3) +
+                                                  "pp");
             // RMS Amplitude string representation (3 significant digits)
-            measurementRMSLabel[channel]->setText(
-                valueToString( analysedData.get()->data(channel)->rms, UNIT_VOLTS, 3 ) + "rms" );
+            measurementRMSLabel[channel]->setText(valueToString(analysedData.get()->data(channel)->rms, UNIT_VOLTS, 3) +
+                                                  "rms");
             // DC Amplitude string representation (3 significant digits)
-            measurementDCLabel[channel]->setText(
-                valueToString( analysedData.get()->data(channel)->dc, UNIT_VOLTS, 3 ) + "=" );
+            measurementDCLabel[channel]->setText(valueToString(analysedData.get()->data(channel)->dc, UNIT_VOLTS, 3) +
+                                                 "=");
             // AC Amplitude string representation (3 significant digits)
-            measurementACLabel[channel]->setText(
-                valueToString( analysedData.get()->data(channel)->ac, UNIT_VOLTS, 3 ) + "~" );
+            measurementACLabel[channel]->setText(valueToString(analysedData.get()->data(channel)->ac, UNIT_VOLTS, 3) +
+                                                 "~");
             // dB Amplitude string representation (3 significant digits)
-            measurementdBLabel[channel]->setText(
-                valueToString( analysedData.get()->data(channel)->dB, UNIT_DECIBEL, 3 ) );
+            measurementdBLabel[channel]->setText(valueToString(analysedData.get()->data(channel)->dB, UNIT_DECIBEL, 3));
             // Frequency string representation (3 significant digits)
             measurementFrequencyLabel[channel]->setText(
-                valueToString( analysedData.get()->data(channel)->frequency, UNIT_HERTZ, 4 ) );
+                valueToString(analysedData.get()->data(channel)->frequency, UNIT_HERTZ, 4));
             // Highlight clipped channel
             QPalette validPalette;
-            if ( analysedData.get()->data(channel)->valid ) { // normal display
-                validPalette.setColor( QPalette::WindowText, view->screen.voltage[channel] );
-                validPalette.setColor( QPalette::Background, view->screen.background );
+            if (analysedData.get()->data(channel)->valid) { // normal display
+                validPalette.setColor(QPalette::WindowText, view->screen.voltage[channel]);
+                validPalette.setColor(QPalette::Background, view->screen.background);
             } else { // warning
-                validPalette.setColor(QPalette::WindowText, Qt::black );
-                validPalette.setColor(QPalette::Background, Qt::red );
+                validPalette.setColor(QPalette::WindowText, Qt::black);
+                validPalette.setColor(QPalette::Background, Qt::red);
             }
-            measurementNameLabel[channel]->setPalette( validPalette );
+            measurementNameLabel[channel]->setPalette(validPalette);
         }
     }
 }
@@ -793,17 +781,19 @@ void DsoWidget::updateOffset(ChannelID channel, double value) {
         scope->spectrum[channel - scope->voltage.size()].offset = value;
 
     if (channel < scope->voltage.size() * 2) {
-        if ( mainSliders.voltageOffsetSlider->value( int( channel ) ) != value ) { // double != comparison is safe in this case
-            const QSignalBlocker blocker(mainSliders.voltageOffsetSlider );
-            mainSliders.voltageOffsetSlider->setValue( int( channel ), value );
+        if (mainSliders.voltageOffsetSlider->value(int(channel)) !=
+            value) { // double != comparison is safe in this case
+            const QSignalBlocker blocker(mainSliders.voltageOffsetSlider);
+            mainSliders.voltageOffsetSlider->setValue(int(channel), value);
         }
-        if ( zoomSliders.voltageOffsetSlider->value( int( channel ) ) != value ) { // double != comparison is safe in this case
-            const QSignalBlocker blocker(zoomSliders.voltageOffsetSlider );
-            zoomSliders.voltageOffsetSlider->setValue( int( channel ), value );
+        if (zoomSliders.voltageOffsetSlider->value(int(channel)) !=
+            value) { // double != comparison is safe in this case
+            const QSignalBlocker blocker(zoomSliders.voltageOffsetSlider);
+            zoomSliders.voltageOffsetSlider->setValue(int(channel), value);
         }
     }
 
-    emit voltageOffsetChanged( channel, value );
+    emit voltageOffsetChanged(channel, value);
 }
 
 /// \brief Translate horizontal position (0..1) from main view to zoom view.
@@ -811,7 +801,7 @@ double DsoWidget::mainToZoom(double position) const {
     double m1 = scope->getMarker(0);
     double m2 = scope->getMarker(1);
     if (m1 > m2) std::swap(m1, m2);
-    return ((position - 0.5) * DIVS_TIME - m1) / std::max( m2 - m1, 1e-9 );
+    return ((position - 0.5) * DIVS_TIME - m1) / std::max(m2 - m1, 1e-9);
 }
 
 /// \brief Translate horizontal position (0..1) from zoom view to main view.
@@ -824,7 +814,7 @@ double DsoWidget::zoomToMain(double position) const {
 
 /// \brief Handles signals affecting trigger position in the zoom view.
 void DsoWidget::adaptTriggerOffsetSlider() {
-    double value = mainToZoom( scope->trigger.offset );
+    double value = mainToZoom(scope->trigger.offset);
 
     LevelSlider &slider = *zoomSliders.triggerOffsetSlider;
     const QSignalBlocker blocker(slider);
@@ -845,7 +835,7 @@ void DsoWidget::adaptTriggerOffsetSlider() {
 /// \param index The index of the slider.
 /// \param value The new triggerPosition in seconds relative to the first
 /// sample.
-void DsoWidget::updateTriggerOffset( int index, double value, bool mainView ) {
+void DsoWidget::updateTriggerOffset(int index, double value, bool mainView) {
     if (index != 0) return;
 
     if (mainView) {
@@ -853,30 +843,30 @@ void DsoWidget::updateTriggerOffset( int index, double value, bool mainView ) {
         adaptTriggerOffsetSlider();
     } else {
         scope->trigger.offset = zoomToMain(value);
-        const QSignalBlocker blocker(mainSliders.triggerOffsetSlider );
-        mainSliders.triggerOffsetSlider->setValue(index, scope->trigger.offset );
+        const QSignalBlocker blocker(mainSliders.triggerOffsetSlider);
+        mainSliders.triggerOffsetSlider->setValue(index, scope->trigger.offset);
     }
 
     updateTriggerDetails();
     updateMarkerDetails();
 
-    emit triggerPositionChanged(scope->trigger.offset );
+    emit triggerPositionChanged(scope->trigger.offset);
 }
 
 /// \brief Handles valueChanged signal from the trigger level slider.
 /// \param channel The index of the slider.
 /// \param value The new trigger level.
 void DsoWidget::updateTriggerLevel(ChannelID channel, double value) {
-    //printf("DW::updateTriggerLevel( %d, %g )\n", channel, value);
+    // printf("DW::updateTriggerLevel( %d, %g )\n", channel, value);
     scope->voltage[channel].trigger = value;
 
-    if ( mainSliders.triggerLevelSlider->value( int( channel ) ) != value ) { // double != comparison is safe in this case
+    if (mainSliders.triggerLevelSlider->value(int(channel)) != value) { // double != comparison is safe in this case
         const QSignalBlocker blocker(mainSliders.triggerLevelSlider);
-        mainSliders.triggerLevelSlider->setValue( int( channel ), value );
+        mainSliders.triggerLevelSlider->setValue(int(channel), value);
     }
-    if ( zoomSliders.triggerLevelSlider->value( int( channel ) ) != value ) { // double != comparison is safe in this case
+    if (zoomSliders.triggerLevelSlider->value(int(channel)) != value) { // double != comparison is safe in this case
         const QSignalBlocker blocker(zoomSliders.triggerLevelSlider);
-        zoomSliders.triggerLevelSlider->setValue( int( channel ), value );
+        zoomSliders.triggerLevelSlider->setValue(int(channel), value);
     }
 
     updateTriggerDetails();
@@ -887,8 +877,8 @@ void DsoWidget::updateTriggerLevel(ChannelID channel, double value) {
 /// \brief Handles valueChanged signal from the marker slider.
 /// \param marker The index of the slider.
 /// \param value The new marker position.
-void DsoWidget::updateMarker( unsigned marker, double value ) {
-    scope->setMarker( marker, value );
+void DsoWidget::updateMarker(unsigned marker, double value) {
+    scope->setMarker(marker, value);
     adaptTriggerOffsetSlider();
     updateMarkerDetails();
 }
@@ -906,16 +896,22 @@ void DsoWidget::updateSlidersSettings() {
         zoomSliders.voltageOffsetSlider->setIndexVisible(channel, scope->voltage[channel].used);
 
         updateOffset(unsigned(scope->voltage.size() + channel), scope->spectrum[channel].offset);
-        mainSliders.voltageOffsetSlider->setColor(unsigned( scope->voltage.size() ) + channel, view->screen.spectrum[channel]);
-        mainSliders.voltageOffsetSlider->setValue(int( scope->voltage.size() + channel ), scope->spectrum[channel].offset);
-        mainSliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel, scope->spectrum[channel].used);
-        zoomSliders.voltageOffsetSlider->setColor(unsigned( scope->voltage.size() ) + channel, view->screen.spectrum[channel]);
-        zoomSliders.voltageOffsetSlider->setValue(int( scope->voltage.size() + channel ), scope->spectrum[channel].offset);
-        zoomSliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel, scope->spectrum[channel].used);
+        mainSliders.voltageOffsetSlider->setColor(unsigned(scope->voltage.size()) + channel,
+                                                  view->screen.spectrum[channel]);
+        mainSliders.voltageOffsetSlider->setValue(int(scope->voltage.size() + channel),
+                                                  scope->spectrum[channel].offset);
+        mainSliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel,
+                                                         scope->spectrum[channel].used);
+        zoomSliders.voltageOffsetSlider->setColor(unsigned(scope->voltage.size()) + channel,
+                                                  view->screen.spectrum[channel]);
+        zoomSliders.voltageOffsetSlider->setValue(int(scope->voltage.size() + channel),
+                                                  scope->spectrum[channel].offset);
+        zoomSliders.voltageOffsetSlider->setIndexVisible(unsigned(scope->voltage.size()) + channel,
+                                                         scope->spectrum[channel].used);
     }
 
     // The trigger position slider
-    mainSliders.triggerOffsetSlider->setValue(0, scope->trigger.offset );
+    mainSliders.triggerOffsetSlider->setValue(0, scope->trigger.offset);
     updateTriggerOffset(0, scope->trigger.offset, true);
     updateTriggerOffset(0, scope->trigger.offset, false);
 
@@ -923,17 +919,15 @@ void DsoWidget::updateSlidersSettings() {
     for (ChannelID channel = 0; channel < spec->channels; ++channel) {
         mainSliders.triggerLevelSlider->setValue(int(channel), scope->voltage[channel].trigger);
         adaptTriggerLevelSlider(mainSliders, channel);
-        mainSliders.triggerLevelSlider->setColor(channel,
-                                             (channel == scope->trigger.source)
-                                                 ? view->screen.voltage[channel]
-                                                 : view->screen.voltage[channel].darker());
+        mainSliders.triggerLevelSlider->setColor(channel, (channel == scope->trigger.source)
+                                                              ? view->screen.voltage[channel]
+                                                              : view->screen.voltage[channel].darker());
         mainSliders.triggerLevelSlider->setIndexVisible(channel, scope->voltage[channel].used);
         zoomSliders.triggerLevelSlider->setValue(int(channel), scope->voltage[channel].trigger);
         adaptTriggerLevelSlider(zoomSliders, channel);
-        zoomSliders.triggerLevelSlider->setColor(channel,
-                                             (channel == scope->trigger.source)
-                                                 ? view->screen.voltage[channel]
-                                                 : view->screen.voltage[channel].darker());
+        zoomSliders.triggerLevelSlider->setColor(channel, (channel == scope->trigger.source)
+                                                              ? view->screen.voltage[channel]
+                                                              : view->screen.voltage[channel].darker());
         zoomSliders.triggerLevelSlider->setIndexVisible(channel, scope->voltage[channel].used);
     }
     updateTriggerDetails();

--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -106,7 +106,7 @@ DsoWidget::DsoWidget(DsoSettingsScope *scope, DsoSettingsView *view, const Dso::
     QPalette tablePalette = palette;
     measurementLayout = new QGridLayout();
     int iii = 0;
-    measurementLayout->setColumnMinimumWidth(iii++, 50);
+    measurementLayout->setColumnMinimumWidth(iii++, 80);
     measurementLayout->setColumnMinimumWidth(iii++, 30);
     measurementLayout->setColumnStretch(iii++, 3);
     measurementLayout->setColumnStretch(iii++, 3);

--- a/openhantek/src/widgets/levelslider.cpp
+++ b/openhantek/src/widgets/levelslider.cpp
@@ -65,7 +65,7 @@ int LevelSlider::addSlider(int index) { return this->addSlider("", index); }
 /// \param text The text that will be shown next to the slider.
 /// \param index The index where the slider should be inserted, 0 to append.
 /// \return The index of the slider, -1 on error.
-int LevelSlider::addSlider(const QString& text, int index) {
+int LevelSlider::addSlider(const QString &text, int index) {
     if (index < -1) return -1;
 
     LevelSliderParameters *parameters = new LevelSliderParameters;
@@ -374,37 +374,31 @@ void LevelSlider::paintEvent(QPaintEvent *event) {
 
         if ((*sliderIt)->text.isEmpty()) {
             QVector<QPoint> needlePoints;
-            QRect& sRect = (*sliderIt)->rect;
+            QRect &sRect = (*sliderIt)->rect;
             const int W = this->sliderWidth;
 
             switch (this->_direction) {
             case Qt::LeftArrow:
-                needlePoints << QPoint(sRect.left() + 4, sRect.top()    )
-                             << QPoint(sRect.left() + 1, sRect.top() + 3)
-                             << QPoint(sRect.left() + 4, sRect.top() + 6)
-                             << QPoint(sRect.left() + W, sRect.top() + 6)
-                             << QPoint(sRect.left() + W, sRect.top()    );
+                needlePoints << QPoint(sRect.left() + 4, sRect.top()) << QPoint(sRect.left() + 1, sRect.top() + 3)
+                             << QPoint(sRect.left() + 4, sRect.top() + 6) << QPoint(sRect.left() + W, sRect.top() + 6)
+                             << QPoint(sRect.left() + W, sRect.top());
                 break;
             case Qt::UpArrow:
-                needlePoints << QPoint(sRect.left(),     sRect.top() + 4)
-                             << QPoint(sRect.left() + 3, sRect.top() + 1)
-                             << QPoint(sRect.left() + 6, sRect.top() + 4)
-                             << QPoint(sRect.left() + 6, sRect.top() + W)
-                             << QPoint(sRect.left(),     sRect.top() + W);
+                needlePoints << QPoint(sRect.left(), sRect.top() + 4) << QPoint(sRect.left() + 3, sRect.top() + 1)
+                             << QPoint(sRect.left() + 6, sRect.top() + 4) << QPoint(sRect.left() + 6, sRect.top() + W)
+                             << QPoint(sRect.left(), sRect.top() + W);
                 break;
             case Qt::DownArrow:
-                needlePoints << QPoint(sRect.left(),     sRect.top() + W - 5)
+                needlePoints << QPoint(sRect.left(), sRect.top() + W - 5)
                              << QPoint(sRect.left() + 3, sRect.top() + W - 2)
-                             << QPoint(sRect.left() + 6, sRect.top() + W - 5)
-                             << QPoint(sRect.left() + 6, sRect.top()        )
-                             << QPoint(sRect.left(),     sRect.top()        );
+                             << QPoint(sRect.left() + 6, sRect.top() + W - 5) << QPoint(sRect.left() + 6, sRect.top())
+                             << QPoint(sRect.left(), sRect.top());
                 break;
             case Qt::RightArrow:
-                needlePoints << QPoint(sRect.left() + W - 5, sRect.top()    )
+                needlePoints << QPoint(sRect.left() + W - 5, sRect.top())
                              << QPoint(sRect.left() + W - 2, sRect.top() + 3)
-                             << QPoint(sRect.left() + W - 5, sRect.top() + 6)
-                             << QPoint(sRect.left(),         sRect.top() + 6)
-                             << QPoint(sRect.left(),         sRect.top()    );
+                             << QPoint(sRect.left() + W - 5, sRect.top() + 6) << QPoint(sRect.left(), sRect.top() + 6)
+                             << QPoint(sRect.left(), sRect.top());
                 break;
             default:
                 break;
@@ -465,30 +459,30 @@ QRect LevelSlider::calculateRect(int sliderId) {
         if (this->slider[sliderId]->text.isEmpty()) {
             this->slider[sliderId]->rect =
                 QRect(0, // Start at the left side
-                      // The needle should be center-aligned, 0.5 pixel offset for
-                      // exact pixelization
+                         // The needle should be center-aligned, 0.5 pixel offset for
+                         // exact pixelization
                       int((this->height() - this->_preMargin - this->_postMargin - 1) *
-                                 (this->slider[sliderId]->maximum - this->slider[sliderId]->value) /
-                                 (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
-                             0.5) +
+                              (this->slider[sliderId]->maximum - this->slider[sliderId]->value) /
+                              (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
+                          0.5) +
                           this->_preMargin - 3,
                       this->sliderWidth, // Fill the whole width
                       7                  // The needle is 7 px wide
-                      );
+                );
         }
         // Or a thin needle with text?
         else {
             this->slider[sliderId]->rect =
                 QRect(0, // Start at the left side
-                      // The needle is at the bottom, the text above it, 0.5 pixel
-                      // offset for exact pixelization
+                         // The needle is at the bottom, the text above it, 0.5 pixel
+                         // offset for exact pixelization
                       int((this->height() - this->_preMargin - this->_postMargin - 1) *
-                                 (this->slider[sliderId]->maximum - this->slider[sliderId]->value) /
-                                 (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
-                             0.5),
+                              (this->slider[sliderId]->maximum - this->slider[sliderId]->value) /
+                              (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
+                          0.5),
                       this->sliderWidth,    // Fill the whole width
                       this->preMargin() + 1 // Use the full margin
-                      );
+                );
         }
     }
     // Or a horizontal slider?
@@ -499,14 +493,14 @@ QRect LevelSlider::calculateRect(int sliderId) {
                 // The needle should be center-aligned, 0.5 pixel offset for exact
                 // pixelization
                 int((this->width() - this->_preMargin - this->_postMargin - 1) *
-                           (this->slider[sliderId]->value - this->slider[sliderId]->minimum) /
-                           (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
-                       0.5) +
+                        (this->slider[sliderId]->value - this->slider[sliderId]->minimum) /
+                        (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
+                    0.5) +
                     this->_preMargin - 3,
                 0,                // Start at the top
                 7,                // The needle is 7 px wide
                 this->sliderWidth // Fill the whole height
-                );
+            );
         }
         // Or a thin needle with text?
         else {
@@ -515,14 +509,14 @@ QRect LevelSlider::calculateRect(int sliderId) {
                 // The needle is at the right side, the text before it, 0.5 pixel
                 // offset for exact pixelization
                 int((this->width() - this->_preMargin - this->_postMargin - 1) *
-                           (this->slider[sliderId]->value - this->slider[sliderId]->minimum) /
-                           (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
-                       0.5) +
+                        (this->slider[sliderId]->value - this->slider[sliderId]->minimum) /
+                        (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
+                    0.5) +
                     this->_preMargin - sliderLength + 1,
                 0,                // Start at the top
                 sliderLength,     // The width depends on the text
                 this->sliderWidth // Fill the whole height
-                );
+            );
         }
     }
 
@@ -537,20 +531,16 @@ int LevelSlider::calculateWidth() {
 
     // Is it a vertical slider?
     if (this->_direction == Qt::RightArrow || this->_direction == Qt::LeftArrow) {
-        for (QList<LevelSliderParameters *>::iterator sliderIt = slider.begin(); sliderIt != slider.end();
-             ++sliderIt) {
+        for (QList<LevelSliderParameters *>::iterator sliderIt = slider.begin(); sliderIt != slider.end(); ++sliderIt) {
             int newSliderWidth = this->fontMetrics().size(0, (*sliderIt)->text).width();
-            if ( newSliderWidth > sliderWidth )
-                sliderWidth = newSliderWidth;
+            if (newSliderWidth > sliderWidth) sliderWidth = newSliderWidth;
         }
     }
     // Or a horizontal slider?
     else {
-        for (QList<LevelSliderParameters *>::iterator sliderIt = slider.begin(); sliderIt != slider.end();
-             ++sliderIt) {
+        for (QList<LevelSliderParameters *>::iterator sliderIt = slider.begin(); sliderIt != slider.end(); ++sliderIt) {
             int newSliderWidth = this->fontMetrics().size(0, (*sliderIt)->text).height();
-            if ( newSliderWidth > sliderWidth )
-                sliderWidth = newSliderWidth;
+            if (newSliderWidth > sliderWidth) sliderWidth = newSliderWidth;
         }
     }
 

--- a/openhantek/src/widgets/levelslider.cpp
+++ b/openhantek/src/widgets/levelslider.cpp
@@ -35,9 +35,9 @@
 /// \param direction The side on which the sliders are shown.
 /// \param parent The parent widget.
 LevelSlider::LevelSlider(Qt::ArrowType direction, QWidget *parent) : QWidget(parent) {
-    QFont font = this->font();
-    font.setPointSize(int(font.pointSize() * 0.8));
-    this->setFont(font);
+    // Set pixel values based on the current dpi scaling
+    this->needleWidth = ((int)(0.55 * this->fontMetrics().height())) + 1; // always an odd number
+    this->sliderWidth = (int)(1.2 * this->fontMetrics().height());
 
     this->pressedSlider = -1;
 
@@ -267,10 +267,10 @@ int LevelSlider::setDirection(Qt::ArrowType direction) {
 
     if (this->_direction == Qt::RightArrow || this->_direction == Qt::LeftArrow) {
         this->_preMargin = this->fontMetrics().lineSpacing();
-        this->_postMargin = 3;
+        this->_postMargin = (this->needleWidth - 1) / 2;
     } else {
         this->_preMargin = this->fontMetrics().averageCharWidth() * 3;
-        this->_postMargin = 3;
+        this->_postMargin = (this->needleWidth - 1) / 2;
     }
 
     return this->_direction;
@@ -374,31 +374,39 @@ void LevelSlider::paintEvent(QPaintEvent *event) {
 
         if ((*sliderIt)->text.isEmpty()) {
             QVector<QPoint> needlePoints;
-            QRect &sRect = (*sliderIt)->rect;
-            const int W = this->sliderWidth;
+            QRect &needleRect = (*sliderIt)->rect;
+            const int peak = 1; // distance from slider to the tip of the needle
+            const int shoulder =
+                peak + this->needleWidth / 2; // distance from slider to the straight part of the needle
 
             switch (this->_direction) {
             case Qt::LeftArrow:
-                needlePoints << QPoint(sRect.left() + 4, sRect.top()) << QPoint(sRect.left() + 1, sRect.top() + 3)
-                             << QPoint(sRect.left() + 4, sRect.top() + 6) << QPoint(sRect.left() + W, sRect.top() + 6)
-                             << QPoint(sRect.left() + W, sRect.top());
+                needlePoints << QPoint(needleRect.left() + shoulder, needleRect.top())
+                             << QPoint(needleRect.left() + peak, needleRect.top() + this->needleWidth / 2)
+                             << QPoint(needleRect.left() + shoulder, needleRect.bottom())
+                             << QPoint(needleRect.right(), needleRect.bottom())
+                             << QPoint(needleRect.right(), needleRect.top());
                 break;
             case Qt::UpArrow:
-                needlePoints << QPoint(sRect.left(), sRect.top() + 4) << QPoint(sRect.left() + 3, sRect.top() + 1)
-                             << QPoint(sRect.left() + 6, sRect.top() + 4) << QPoint(sRect.left() + 6, sRect.top() + W)
-                             << QPoint(sRect.left(), sRect.top() + W);
+                needlePoints << QPoint(needleRect.left(), needleRect.top() + shoulder)
+                             << QPoint(needleRect.left() + this->needleWidth / 2, needleRect.top() + peak)
+                             << QPoint(needleRect.right(), needleRect.top() + shoulder)
+                             << QPoint(needleRect.right(), needleRect.bottom())
+                             << QPoint(needleRect.left(), needleRect.bottom());
                 break;
             case Qt::DownArrow:
-                needlePoints << QPoint(sRect.left(), sRect.top() + W - 5)
-                             << QPoint(sRect.left() + 3, sRect.top() + W - 2)
-                             << QPoint(sRect.left() + 6, sRect.top() + W - 5) << QPoint(sRect.left() + 6, sRect.top())
-                             << QPoint(sRect.left(), sRect.top());
+                needlePoints << QPoint(needleRect.left(), needleRect.bottom() - shoulder)
+                             << QPoint(needleRect.left() + this->needleWidth / 2, needleRect.bottom() - peak)
+                             << QPoint(needleRect.right(), needleRect.bottom() - shoulder)
+                             << QPoint(needleRect.right(), needleRect.top())
+                             << QPoint(needleRect.left(), needleRect.top());
                 break;
             case Qt::RightArrow:
-                needlePoints << QPoint(sRect.left() + W - 5, sRect.top())
-                             << QPoint(sRect.left() + W - 2, sRect.top() + 3)
-                             << QPoint(sRect.left() + W - 5, sRect.top() + 6) << QPoint(sRect.left(), sRect.top() + 6)
-                             << QPoint(sRect.left(), sRect.top());
+                needlePoints << QPoint(needleRect.right() - shoulder, needleRect.top())
+                             << QPoint(needleRect.right() - peak, needleRect.top() + this->needleWidth / 2)
+                             << QPoint(needleRect.right() - shoulder, needleRect.bottom())
+                             << QPoint(needleRect.left(), needleRect.bottom())
+                             << QPoint(needleRect.left(), needleRect.top());
                 break;
             default:
                 break;
@@ -465,9 +473,9 @@ QRect LevelSlider::calculateRect(int sliderId) {
                               (this->slider[sliderId]->maximum - this->slider[sliderId]->value) /
                               (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
                           0.5) +
-                          this->_preMargin - 3,
+                          this->_preMargin - (this->needleWidth / 2),
                       this->sliderWidth, // Fill the whole width
-                      7                  // The needle is 7 px wide
+                      this->needleWidth  // one needle width high
                 );
         }
         // Or a thin needle with text?
@@ -496,10 +504,10 @@ QRect LevelSlider::calculateRect(int sliderId) {
                         (this->slider[sliderId]->value - this->slider[sliderId]->minimum) /
                         (this->slider[sliderId]->maximum - this->slider[sliderId]->minimum) +
                     0.5) +
-                    this->_preMargin - 3,
-                0,                // Start at the top
-                7,                // The needle is 7 px wide
-                this->sliderWidth // Fill the whole height
+                    this->_preMargin - (this->needleWidth / 2),
+                0, // Start at the top
+                this->needleWidth,
+                this->sliderWidth // As high as the slider
             );
         }
         // Or a thin needle with text?
@@ -526,9 +534,6 @@ QRect LevelSlider::calculateRect(int sliderId) {
 /// \brief Search for the widest slider element.
 /// \return The calculated width of the slider.
 int LevelSlider::calculateWidth() {
-    // At least 12 px for the needles
-    sliderWidth = 12;
-
     // Is it a vertical slider?
     if (this->_direction == Qt::RightArrow || this->_direction == Qt::LeftArrow) {
         for (QList<LevelSliderParameters *>::iterator sliderIt = slider.begin(); sliderIt != slider.end(); ++sliderIt) {

--- a/openhantek/src/widgets/levelslider.h
+++ b/openhantek/src/widgets/levelslider.h
@@ -77,6 +77,7 @@ class LevelSlider : public QWidget {
     int pressedSlider;                     ///< The currently pressed (moved) slider
     int sliderWidth;                       ///< The slider width (dimension orthogonal to the sliding
                                            /// direction)
+    int needleWidth;                       ///< Width of the needle (parallel to sliding direction)
 
     Qt::ArrowType _direction; ///< The direction the sliders point to
     int _preMargin;           ///< The margin before the minimum slider position

--- a/openhantek/translations/openhantek_de.ts
+++ b/openhantek/translations/openhantek_de.ts
@@ -305,12 +305,12 @@
 <context>
     <name>DsoWidget</name>
     <message>
+        <location filename="../src/dsowidget.cpp" line="494"/>
         <location filename="../src/dsowidget.cpp" line="496"/>
-        <location filename="../src/dsowidget.cpp" line="498"/>
-        <location filename="../src/dsowidget.cpp" line="533"/>
+        <location filename="../src/dsowidget.cpp" line="527"/>
+        <location filename="../src/dsowidget.cpp" line="565"/>
         <location filename="../src/dsowidget.cpp" line="573"/>
-        <location filename="../src/dsowidget.cpp" line="581"/>
-        <location filename="../src/dsowidget.cpp" line="600"/>
+        <location filename="../src/dsowidget.cpp" line="592"/>
         <source>/div</source>
         <translation>/div</translation>
     </message>
@@ -325,59 +325,59 @@
         <translation>Marker</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>ON</source>
         <translation>EIN</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>OFF</source>
         <translation>AUS</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="486"/>
+        <location filename="../src/dsowidget.cpp" line="484"/>
         <source>Markers  </source>
         <translation>Merker </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="487"/>
+        <location filename="../src/dsowidget.cpp" line="485"/>
         <source>Time: </source>
         <translation>Zeit: </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="488"/>
+        <location filename="../src/dsowidget.cpp" line="486"/>
         <source>Frequency: </source>
         <translation>Frequenz: </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="491"/>
+        <location filename="../src/dsowidget.cpp" line="489"/>
         <source>Zoom x%L1  </source>
         <translation>Zoom x%L1</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="493"/>
+        <location filename="../src/dsowidget.cpp" line="491"/>
         <source>Zoom ---  </source>
         <translation>Zoom ---</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="545"/>
+        <location filename="../src/dsowidget.cpp" line="539"/>
         <source>%L1%</source>
         <translation>%L1%</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="558"/>
+        <location filename="../src/dsowidget.cpp" line="552"/>
         <source>%1  %2  %3  %4  %5</source>
         <translation>%1  %2  %3  %4 %5</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="591"/>
+        <location filename="../src/dsowidget.cpp" line="583"/>
         <source>/s</source>
         <translation>/s</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="691"/>
+        <location filename="../src/dsowidget.cpp" line="680"/>
         <source> on screen</source>
         <translation> angezeigt</translation>
     </message>

--- a/openhantek/translations/openhantek_es.ts
+++ b/openhantek/translations/openhantek_es.ts
@@ -315,69 +315,69 @@
         <translation>Marcadores</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="486"/>
+        <location filename="../src/dsowidget.cpp" line="484"/>
         <source>Markers  </source>
         <translation>Marcadores  </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="487"/>
+        <location filename="../src/dsowidget.cpp" line="485"/>
         <source>Time: </source>
         <translation>Tiempo: </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="488"/>
+        <location filename="../src/dsowidget.cpp" line="486"/>
         <source>Frequency: </source>
         <translation>Frecuencia: </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="491"/>
+        <location filename="../src/dsowidget.cpp" line="489"/>
         <source>Zoom x%L1  </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="493"/>
+        <location filename="../src/dsowidget.cpp" line="491"/>
         <source>Zoom ---  </source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/dsowidget.cpp" line="494"/>
         <location filename="../src/dsowidget.cpp" line="496"/>
-        <location filename="../src/dsowidget.cpp" line="498"/>
-        <location filename="../src/dsowidget.cpp" line="533"/>
+        <location filename="../src/dsowidget.cpp" line="527"/>
+        <location filename="../src/dsowidget.cpp" line="565"/>
         <location filename="../src/dsowidget.cpp" line="573"/>
-        <location filename="../src/dsowidget.cpp" line="581"/>
-        <location filename="../src/dsowidget.cpp" line="600"/>
+        <location filename="../src/dsowidget.cpp" line="592"/>
         <source>/div</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="545"/>
+        <location filename="../src/dsowidget.cpp" line="539"/>
         <source>%L1%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="558"/>
+        <location filename="../src/dsowidget.cpp" line="552"/>
         <source>%1  %2  %3  %4  %5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="591"/>
+        <location filename="../src/dsowidget.cpp" line="583"/>
         <source>/s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="691"/>
+        <location filename="../src/dsowidget.cpp" line="680"/>
         <source> on screen</source>
         <translation> en pantalla</translation>
     </message>

--- a/openhantek/translations/openhantek_fr.ts
+++ b/openhantek/translations/openhantek_fr.ts
@@ -315,69 +315,69 @@
         <translation>Repères</translation>
     </message>
     <message>
+        <location filename="../src/dsowidget.cpp" line="494"/>
         <location filename="../src/dsowidget.cpp" line="496"/>
-        <location filename="../src/dsowidget.cpp" line="498"/>
-        <location filename="../src/dsowidget.cpp" line="533"/>
+        <location filename="../src/dsowidget.cpp" line="527"/>
+        <location filename="../src/dsowidget.cpp" line="565"/>
         <location filename="../src/dsowidget.cpp" line="573"/>
-        <location filename="../src/dsowidget.cpp" line="581"/>
-        <location filename="../src/dsowidget.cpp" line="600"/>
+        <location filename="../src/dsowidget.cpp" line="592"/>
         <source>/div</source>
         <translation>/div</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="486"/>
+        <location filename="../src/dsowidget.cpp" line="484"/>
         <source>Markers  </source>
         <translation>Repères  </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="487"/>
+        <location filename="../src/dsowidget.cpp" line="485"/>
         <source>Time: </source>
         <translation>Temps : </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="488"/>
+        <location filename="../src/dsowidget.cpp" line="486"/>
         <source>Frequency: </source>
         <translation>Fréquence : </translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="491"/>
+        <location filename="../src/dsowidget.cpp" line="489"/>
         <source>Zoom x%L1  </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="493"/>
+        <location filename="../src/dsowidget.cpp" line="491"/>
         <source>Zoom ---  </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="545"/>
+        <location filename="../src/dsowidget.cpp" line="539"/>
         <source>%L1%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="558"/>
+        <location filename="../src/dsowidget.cpp" line="552"/>
         <source>%1  %2  %3  %4  %5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="591"/>
+        <location filename="../src/dsowidget.cpp" line="583"/>
         <source>/s</source>
         <translation>/s</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="691"/>
+        <location filename="../src/dsowidget.cpp" line="680"/>
         <source> on screen</source>
         <translation> à l&apos;écran</translation>
     </message>

--- a/openhantek/translations/openhantek_it.ts
+++ b/openhantek/translations/openhantek_it.ts
@@ -315,69 +315,69 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/dsowidget.cpp" line="494"/>
         <location filename="../src/dsowidget.cpp" line="496"/>
-        <location filename="../src/dsowidget.cpp" line="498"/>
-        <location filename="../src/dsowidget.cpp" line="533"/>
+        <location filename="../src/dsowidget.cpp" line="527"/>
+        <location filename="../src/dsowidget.cpp" line="565"/>
         <location filename="../src/dsowidget.cpp" line="573"/>
-        <location filename="../src/dsowidget.cpp" line="581"/>
-        <location filename="../src/dsowidget.cpp" line="600"/>
+        <location filename="../src/dsowidget.cpp" line="592"/>
         <source>/div</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="486"/>
+        <location filename="../src/dsowidget.cpp" line="484"/>
         <source>Markers  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="487"/>
+        <location filename="../src/dsowidget.cpp" line="485"/>
         <source>Time: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="488"/>
+        <location filename="../src/dsowidget.cpp" line="486"/>
         <source>Frequency: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="491"/>
+        <location filename="../src/dsowidget.cpp" line="489"/>
         <source>Zoom x%L1  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="493"/>
+        <location filename="../src/dsowidget.cpp" line="491"/>
         <source>Zoom ---  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="545"/>
+        <location filename="../src/dsowidget.cpp" line="539"/>
         <source>%L1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="558"/>
+        <location filename="../src/dsowidget.cpp" line="552"/>
         <source>%1  %2  %3  %4  %5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="591"/>
+        <location filename="../src/dsowidget.cpp" line="583"/>
         <source>/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="691"/>
+        <location filename="../src/dsowidget.cpp" line="680"/>
         <source> on screen</source>
         <translation type="unfinished"></translation>
     </message>

--- a/openhantek/translations/openhantek_pt.ts
+++ b/openhantek/translations/openhantek_pt.ts
@@ -313,12 +313,12 @@
         <translation type="vanished">Zoom x%L1</translation>
     </message>
     <message>
+        <location filename="../src/dsowidget.cpp" line="494"/>
         <location filename="../src/dsowidget.cpp" line="496"/>
-        <location filename="../src/dsowidget.cpp" line="498"/>
-        <location filename="../src/dsowidget.cpp" line="533"/>
+        <location filename="../src/dsowidget.cpp" line="527"/>
+        <location filename="../src/dsowidget.cpp" line="565"/>
         <location filename="../src/dsowidget.cpp" line="573"/>
-        <location filename="../src/dsowidget.cpp" line="581"/>
-        <location filename="../src/dsowidget.cpp" line="600"/>
+        <location filename="../src/dsowidget.cpp" line="592"/>
         <source>/div</source>
         <translation>/div</translation>
     </message>
@@ -333,54 +333,54 @@
         <translation type="unfinished">Marcadores</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="450"/>
-        <location filename="../src/dsowidget.cpp" line="464"/>
+        <location filename="../src/dsowidget.cpp" line="447"/>
+        <location filename="../src/dsowidget.cpp" line="462"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="486"/>
+        <location filename="../src/dsowidget.cpp" line="484"/>
         <source>Markers  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="487"/>
+        <location filename="../src/dsowidget.cpp" line="485"/>
         <source>Time: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="488"/>
+        <location filename="../src/dsowidget.cpp" line="486"/>
         <source>Frequency: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="491"/>
+        <location filename="../src/dsowidget.cpp" line="489"/>
         <source>Zoom x%L1  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="493"/>
+        <location filename="../src/dsowidget.cpp" line="491"/>
         <source>Zoom ---  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="545"/>
+        <location filename="../src/dsowidget.cpp" line="539"/>
         <source>%L1%</source>
         <translation>%L1%</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="558"/>
+        <location filename="../src/dsowidget.cpp" line="552"/>
         <source>%1  %2  %3  %4  %5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="691"/>
+        <location filename="../src/dsowidget.cpp" line="680"/>
         <source> on screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -397,7 +397,7 @@
         <translation type="vanished">%1  %2  %3  %4</translation>
     </message>
     <message>
-        <location filename="../src/dsowidget.cpp" line="591"/>
+        <location filename="../src/dsowidget.cpp" line="583"/>
         <source>/s</source>
         <translation>/s</translation>
     </message>


### PR DESCRIPTION
Currently the needle of the slider used to set the trigger level has a hard coded width of 7px. When using the program on a 4k screen with 200% scaling the vast majority of the programm works/looks as expected. But the needle does not scale at all, it is tiny and difficult to click.
The needle width now depends on `fontMetrics().height()` which scales correctly.

@Ho-Ro: It seems like many of the files in this repo are not formatted according to `openhantek/.clang-format`. Commit fb7b56e is the result of  `clang-format -style file -i src/dsowidget.cpp src/widgets/levelslider.cpp src/widgets/levelslider.h` on the current master.
Maybe you can make one commit which correctly formats all files? That would help in keeping other pull requests small.