### PR TITLE
Voltage dock math improves attenuation voltage to facilities view in graph

### DIFF
--- a/openhantek/src/docks/VoltageDock.cpp
+++ b/openhantek/src/docks/VoltageDock.cpp
@@ -70,12 +70,8 @@ VoltageDock::VoltageDock( DsoSettingsScope *scope, const Dso::ControlSpecificati
         dockLayout->addWidget( b.usedCheckBox, row, 0 );
         dockLayout->addWidget( b.gainComboBox, row++, 1, 1, 2 );
         dockLayout->addWidget( b.invertCheckBox, row, 0 );
-        if ( channel < spec->channels ) {
-            dockLayout->addWidget( b.attnSpinBox, row, 1, 1, 1 );
-            dockLayout->addWidget( b.miscComboBox, row++, 2, 1, 1 );
-        } else {
-            dockLayout->addWidget( b.miscComboBox, row++, 1, 1, 2 );
-        }
+        dockLayout->addWidget( b.attnSpinBox, row, 1, 1, 1 );
+        dockLayout->addWidget( b.miscComboBox, row++, 2, 1, 1 );
 
         // draw divider line
         if ( channel < spec->channels ) {


### PR DESCRIPTION
At times, when using the probe with high attenuation, the mathematical function is outside the standards of the screen, requiring the use of attenuation to correct the visualization.

Before:
![before](https://user-images.githubusercontent.com/15022157/97793979-49ca2a00-1bd2-11eb-9c5d-cf3eb6194857.png)


After:
![after](https://user-images.githubusercontent.com/15022157/97793981-53ec2880-1bd2-11eb-8d67-f30668de19b3.png)
