### PR TITLE
Only use font settings in the dsowidget, not in system controls or dialogs

### DIFF
--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -8,6 +8,7 @@
 #include <QLabel>
 #include <QSignalBlocker>
 #include <QTimer>
+#include <QSettings>
 
 #include "dsowidget.h"
 
@@ -20,6 +21,7 @@
 #include "glscope.h"
 #include "scopesettings.h"
 #include "viewconstants.h"
+#include "viewsettings.h"
 #include "widgets/datagrid.h"
 #include "widgets/levelslider.h"
 
@@ -307,6 +309,24 @@ DsoWidget::DsoWidget( DsoSettingsScope *scope, DsoSettingsView *view, const Dso:
         zoomScope->updateCursor();
     } );
     zoomSliders.markerSlider->setEnabled( false );
+
+    initialiseFonts();
+}
+
+void DsoWidget::initialiseFonts() {
+    QSettings storeSettings;
+
+    storeSettings.beginGroup( "view" );
+    int fontSize = Dso::InterpolationMode( storeSettings.value( "fontSize" ).toInt() );
+    QString font = storeSettings.value( "font" ).toString();
+    int condensed = storeSettings.value( "condensed" ).toInt();
+    storeSettings.endGroup(); // view
+
+    QFont f = this->font();
+    f.setFamily( font );
+    f.setStretch( condensed );
+    f.setPointSize( fontSize );
+    this->setFont( f );
 }
 
 

--- a/openhantek/src/dsowidget.h
+++ b/openhantek/src/dsowidget.h
@@ -46,6 +46,7 @@ class DsoWidget : public QWidget {
 
   protected:
     virtual void showEvent( QShowEvent *event );
+    void initialiseFonts();
     void setupSliders( Sliders &sliders );
     void adaptTriggerLevelSlider( DsoWidget::Sliders &sliders, ChannelID channel );
     void adaptTriggerOffsetSlider();

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -167,14 +167,10 @@ int main( int argc, char *argv[] ) {
         fontSize = qBound( 6, fontSize, 24 ); // values < 6 do not scale correctly
         // printf( "automatic fontSize: %d\n", fontSize );
     }
-    QFont f = openHantekApplication.font();
-    f.setFamily( font ); // Fusion style + Arial (default) -> fit on small screen (Y >= 720 pixel)
-    f.setStretch( condensed );
-    f.setPointSize( fontSize ); // scales the widgets accordingly
-    openHantekApplication.setFont( f );
-    openHantekApplication.setFont( f, "QWidget" ); // on some systems the 2nd argument is required
     storeSettings->beginGroup( "view" );
     storeSettings->setValue( "fontSize", fontSize );
+    storeSettings->setValue( "condensed", condensed );
+    storeSettings->setValue( "font", font );
     storeSettings->endGroup(); // view
     delete storeSettings;      // not needed anymore
 


### PR DESCRIPTION
This change prevents the various font options from applying to dialogs, menus or controls, only applying them to the scope screen. Dialogs, menus and controls will use the system font settings for the relevant platform.

The reason for the change is partly just general consistency and user expectation, but mainly driven by the poor experience on MacBook Pros with retina displays. While I find it useful to be able to vary the font size on the scope screen itself, I think it's less useful on dialogs.

The screenshots show the before and after experience on Linux and Mac. I haven't been able to build successfully on Windows so far but expect it to be similar.

I'm not sure what's causing the other visual differences and the missing buttons on the left in the Mac build but this is the same if I build master or the latest stable release with no changes, so I'm confident I haven't actually broken anything with this change.

## Retina MacBook Pro
### Before
<img width="768" alt="mac-before" src="https://user-images.githubusercontent.com/3910485/106350096-66881200-6327-11eb-82c0-6b78c688c3a7.png">
<img width="2032" alt="mac-before2" src="https://user-images.githubusercontent.com/3910485/106350098-6d168980-6327-11eb-94be-1ce378bad4a7.png">

### After
<img width="682" alt="mac-after" src="https://user-images.githubusercontent.com/3910485/106350131-b070f800-6327-11eb-94af-7c2dfe7089e1.png">
<img width="2032" alt="mac-after2" src="https://user-images.githubusercontent.com/3910485/106350135-b49d1580-6327-11eb-944d-7d72e7e6f628.png">

## Linux
### Before
![linux-before](https://user-images.githubusercontent.com/3910485/106369812-988d8880-63a8-11eb-847b-cfb3d6279b2c.jpg)
![linux-before2](https://user-images.githubusercontent.com/3910485/106369816-9cb9a600-63a8-11eb-8bd7-de01311d1912.jpg)

### After
![linux-after](https://user-images.githubusercontent.com/3910485/106350196-0e054480-6328-11eb-93d2-a24a2bf91b4a.jpg)
![linux-after-dso](https://user-images.githubusercontent.com/3910485/106350198-12c9f880-6328-11eb-966d-d284661fc96b.jpg)
