### PR TITLE
Fix incorrect vertical alignment on measurementMiscLabel

### DIFF
--- a/openhantek/src/dsowidget.cpp
+++ b/openhantek/src/dsowidget.cpp
@@ -125,7 +125,7 @@ DsoWidget::DsoWidget( DsoSettingsScope *scope, DsoSettingsView *view, const Dso:
         measurementNameLabel[ channel ]->setPalette( voltagePalette );
         measurementNameLabel[ channel ]->setAutoFillBackground( true );
         measurementMiscLabel.push_back( new QLabel() );
-        measurementMiscLabel[ channel ]->setAlignment( Qt::AlignCenter );
+        measurementMiscLabel[ channel ]->setAlignment( Qt::AlignHCenter );
         measurementMiscLabel[ channel ]->setPalette( voltagePalette );
         measurementGainLabel.push_back( new QLabel() );
         measurementGainLabel[ channel ]->setAlignment( Qt::AlignRight );


### PR DESCRIPTION
Signed-off-by: dougep <3910485+dougep@users.noreply.github.com>

Fix the vertical alignment issue pointed out by @Ho-Ro in #156 . This wasn't actually related to that change, it was just highlighted by it for some reason.

### Before
![image](https://user-images.githubusercontent.com/3910485/106403681-fcd14a80-6483-11eb-9c7d-c9ae16f26a3c.png)

### After
![image](https://user-images.githubusercontent.com/3910485/106403790-6b160d00-6484-11eb-9e01-15aeb03e534c.png)
