### PR TITLE
Define target context for lambda connection

### DIFF
--- a/openhantek/src/mainwindow.cpp
+++ b/openhantek/src/mainwindow.cpp
@@ -259,7 +259,7 @@ MainWindow::MainWindow( HantekDsoControl *dsoControl, DsoSettings *settings, Exp
     connect( spectrumDock, &SpectrumDock::magnitudeChanged, dsoWidget, &DsoWidget::updateSpectrumMagnitude );
 
     // Started/stopped signals from oscilloscope
-    connect( dsoControl, &HantekDsoControl::samplingStatusChanged, [this]( bool enabled ) {
+    connect( dsoControl, &HantekDsoControl::samplingStatusChanged, this, [this]( bool enabled ) {
         QSignalBlocker blocker( this->ui->actionSampling );
         if ( enabled ) {
             this->ui->actionSampling->setIcon( this->iconPause );


### PR DESCRIPTION
The signal is emitted from another thread an needs to become a
queued connection. Fixes a crash/assert when using Qt debug build.