### PR TITLE
Add JSON Exporter

### DIFF
--- a/openhantek/src/exporting/exportcsv.h
+++ b/openhantek/src/exporting/exportcsv.h
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0+
 
 #pragma once
+#include "exporterdata.h"
 #include "exporterinterface.h"
+
+#include <QFile>
+#include <QTextStream>
 
 class ExporterCSV : public ExporterInterface {
     Q_DECLARE_TR_FUNCTIONS( LegacyExportDrawer )
@@ -17,5 +21,8 @@ class ExporterCSV : public ExporterInterface {
     float progress() override;
 
   private:
+    QFile *getFile();
+    void fillHeaders( QTextStream &jsonStream, const ExporterData &dto, const char *sep );
+    void fillData( QTextStream &jsonStream, const ExporterData &dto, const char *sep );
     std::shared_ptr< PPresult > data;
 };

--- a/openhantek/src/exporting/exporterdata.cpp
+++ b/openhantek/src/exporting/exporterdata.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+#include "exporterdata.h"
+
+ExporterData::ExporterData( const std::shared_ptr< PPresult > &data, const DsoSettingsScope &scope ) {
+    _isSpectrumUsed = false;
+    _timeInterval = 0;
+    _freqInterval = 0;
+    _maxRow = 0;
+    _chCount = scope.voltage.size();
+    _voltageData = std::vector< const SampleValues * >( size_t( _chCount ), nullptr );
+    _spectrumData = std::vector< const SampleValues * >( size_t( _chCount ), nullptr );
+
+    for ( ChannelID channel = 0; channel < _chCount; ++channel ) {
+        if ( data->data( channel ) ) {
+            if ( scope.voltage[ channel ].used ) {
+                _voltageData[ channel ] = &( data->data( channel )->voltage );
+                _maxRow = qMax( _maxRow, _voltageData[ channel ]->sample.size() );
+                _timeInterval = data->data( channel )->voltage.interval;
+            }
+            if ( scope.spectrum[ channel ].used ) {
+                _spectrumData[ channel ] = &( data->data( channel )->spectrum );
+                _maxRow = qMax( _maxRow, _spectrumData[ channel ]->sample.size() );
+                _freqInterval = data->data( channel )->spectrum.interval;
+                _isSpectrumUsed = true;
+            }
+        }
+    }
+}

--- a/openhantek/src/exporting/exporterdata.h
+++ b/openhantek/src/exporting/exporterdata.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+#pragma once
+
+#include "exporterregistry.h"
+#include "post/ppresult.h"
+#include "scopesettings.h"
+
+#include <memory>
+#include <vector>
+
+class ExporterData {
+  public:
+    ExporterData( const std::shared_ptr< PPresult > &data, const DsoSettingsScope &scope );
+
+    const size_t &getChannelsCount() const { return _chCount; }
+    const size_t &getMaxRow() const { return _maxRow; }
+    const bool &isSpectrumUsed() const { return _isSpectrumUsed; }
+    const double &getTimeInterval() const { return _timeInterval; }
+    const double &getFreqInterval() const { return _freqInterval; }
+    std::vector< const SampleValues * > const &getVoltageData() const { return _voltageData; }
+    std::vector< const SampleValues * > const &getSpectrumData() const { return _spectrumData; }
+
+  private:
+    size_t _chCount;
+    size_t _maxRow;
+    bool _isSpectrumUsed;
+    double _timeInterval;
+    double _freqInterval;
+    std::vector< const SampleValues * > _voltageData;
+    std::vector< const SampleValues * > _spectrumData;
+};

--- a/openhantek/src/exporting/exportjson.cpp
+++ b/openhantek/src/exporting/exportjson.cpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0+
+// Sandro Sobczyński <sandro.sobczynski@gmail.com>
+
+#include "exportjson.h"
+#include "dsosettings.h"
+#include "exporterregistry.h"
+#include "iconfont/QtAwesome.h"
+#include "post/ppresult.h"
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QFileDialog>
+#include <QLocale>
+#include <QTextStream>
+
+ExporterJSON::ExporterJSON() {}
+
+void ExporterJSON::create( ExporterRegistry *newRegistry ) {
+    this->registry = newRegistry;
+    data.reset();
+}
+
+int ExporterJSON::faIcon() { return fa::filetexto; }
+
+QString ExporterJSON::name() { return tr( "Export &JSON .." ); }
+
+ExporterInterface::Type ExporterJSON::type() { return Type::SnapshotExport; }
+
+bool ExporterJSON::samples( const std::shared_ptr< PPresult > newData ) {
+    data = std::move( newData );
+    return false;
+}
+
+QFile *ExporterJSON::getFile() {
+    QFileDialog fileDialog( nullptr, tr( "Save JSON" ), QString(), tr( "Java Script Object Notation (*.json)" ) );
+    fileDialog.setFileMode( QFileDialog::AnyFile );
+    fileDialog.setAcceptMode( QFileDialog::AcceptSave );
+    fileDialog.setOption( QFileDialog::DontUseNativeDialog );
+    if ( fileDialog.exec() != QDialog::Accepted )
+        return nullptr;
+
+    QFile *jsonFile = new QFile( fileDialog.selectedFiles().first() );
+    if ( !jsonFile->open( QIODevice::WriteOnly | QIODevice::Text ) )
+        return nullptr;
+    return jsonFile;
+}
+
+void ExporterJSON::fillData( QTextStream &jsonStream, const ExporterData &dto ) {
+    std::vector< const SampleValues * > voltageData = dto.getVoltageData();
+    std::vector< const SampleValues * > spectrumData = dto.getSpectrumData();
+
+    jsonStream << "[\n";
+    const char *indent = "  ";
+
+    for ( unsigned int row = 0; row < dto.getMaxRow(); ++row ) {
+        jsonStream << indent << "{\n";
+
+        QString objInString; // to easily remove latest comma in json object
+        QTextStream objInStream( &objInString );
+        objInStream.setRealNumberNotation( QTextStream::FixedNotation );
+        objInStream.setRealNumberPrecision( 10 );
+
+        objInStream << indent << indent << "\"time\": " << dto.getTimeInterval() * row << ",\n";
+
+        for ( ChannelID channel = 0; channel < dto.getChannelsCount(); ++channel )
+            if ( voltageData[ channel ] != nullptr ) {
+                objInStream << indent << indent << '\"' << registry->settings->scope.voltage[ channel ].name << "\": ";
+                if ( row < voltageData[ channel ]->sample.size() )
+                    objInStream << voltageData[ channel ]->sample[ row ];
+                else
+                    objInStream << "\": null";
+                objInStream << ",\n";
+            }
+
+        if ( dto.isSpectrumUsed() ) {
+            objInStream << indent << indent << "\"freq\": " << dto.getFreqInterval() * row << ",\n";
+            for ( ChannelID channel = 0; channel < dto.getChannelsCount(); ++channel ) {
+                if ( spectrumData[ channel ] != nullptr ) {
+                    objInStream << indent << indent << '\"' << registry->settings->scope.spectrum[ channel ].name << "\": ";
+                    if ( row < spectrumData[ channel ]->sample.size() )
+                        objInStream << spectrumData[ channel ]->sample[ row ];
+                    else
+                        objInStream << "null";
+                    objInStream << ",\n";
+                }
+            }
+        }
+
+        jsonStream << objInString.mid( 0, objInString.length() - 2 ) << '\n' << indent << '}';
+        if ( row != dto.getMaxRow() - 1 )
+            jsonStream << ',';
+        jsonStream << '\n';
+    }
+    jsonStream << "]\n";
+}
+
+bool ExporterJSON::save() {
+    QFile *jsonFile = getFile();
+    if ( jsonFile == nullptr )
+        return false;
+
+    QTextStream jsonStream( jsonFile );
+    jsonStream.setRealNumberNotation( QTextStream::FixedNotation );
+    jsonStream.setRealNumberPrecision( 10 );
+
+    ExporterData dto = ExporterData( data, registry->settings->scope );
+    fillData( jsonStream, dto );
+
+    jsonFile->close();
+    delete jsonFile;
+
+    return true;
+}
+
+
+float ExporterJSON::progress() { return data ? 1.0f : 0; }

--- a/openhantek/src/exporting/exportjson.h
+++ b/openhantek/src/exporting/exportjson.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0+
+// Sandro Sobczyński <sandro.sobczynski@gmail.com>
+
+#pragma once
+#include "exporterdata.h"
+#include "exporterinterface.h"
+
+#include <QFile>
+#include <QTextStream>
+
+class ExporterJSON : public ExporterInterface {
+    Q_DECLARE_TR_FUNCTIONS( LegacyExportDrawer )
+
+  public:
+    ExporterJSON();
+    void create( ExporterRegistry *registry ) override;
+    int faIcon() override;
+    QString name() override;
+    Type type() override;
+    bool samples( const std::shared_ptr< PPresult > newData ) override;
+    bool save() override;
+    float progress() override;
+
+  private:
+    QFile *getFile();
+    void fillData( QTextStream &jsonStream, const ExporterData &dto );
+    std::shared_ptr< PPresult > data;
+};

--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -45,6 +45,7 @@
 
 // Exporter
 #include "exporting/exportcsv.h"
+#include "exporting/exportjson.h"
 #include "exporting/exporterprocessor.h"
 #include "exporting/exporterregistry.h"
 // legacy img and pdf export is replaced by MainWindow::screenshot()
@@ -246,8 +247,10 @@ int main( int argc, char *argv[] ) {
     //////// Create exporters ////////
     ExporterRegistry exportRegistry( spec, &settings );
     ExporterCSV exporterCSV;
+    ExporterJSON exporterJSON;
     ExporterProcessor samplesToExportRaw( &exportRegistry );
     exportRegistry.registerExporter( &exporterCSV );
+    exportRegistry.registerExporter( &exporterJSON );
 
     //////// Create post processing objects ////////
     QThread postProcessingThread;

--- a/openhantek/translations/openhantek_de.ts
+++ b/openhantek/translations/openhantek_de.ts
@@ -838,6 +838,21 @@
         <source>MATH</source>
         <translation type="vanished">MATH</translation>
     </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="25"/>
+        <source>Export &amp;JSON ..</source>
+        <translation>Exportiere &amp;JSON ..</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Save JSON</source>
+        <translation>JSON speichern</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Java Script Object Notation (*.json)</source>
+        <translation>Java Script Object Notation (*.json)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/openhantek/translations/openhantek_es.ts
+++ b/openhantek/translations/openhantek_es.ts
@@ -742,6 +742,21 @@
         <source>Save CSV</source>
         <translation>Guardar CSV</translation>
     </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="25"/>
+        <source>Export &amp;JSON ..</source>
+        <translation>Exportar &amp;JSON ..</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Save JSON</source>
+        <translation>Guardar JSON</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Java Script Object Notation (*.json)</source>
+        <translation>Java Script Object Notation (*.json)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/openhantek/translations/openhantek_fr.ts
+++ b/openhantek/translations/openhantek_fr.ts
@@ -798,6 +798,21 @@
         <source>SPM</source>
         <translation type="vanished">SPM</translation>
     </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="25"/>
+        <source>Export &amp;JSON ..</source>
+        <translation>Exporter &amp;JSON ..</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Save JSON</source>
+        <translation>Enregistrer JSON</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Java Script Object Notation (*.json)</source>
+        <translation>Java Script Object Notation (*.json)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/openhantek/translations/openhantek_it.ts
+++ b/openhantek/translations/openhantek_it.ts
@@ -595,6 +595,21 @@
         <translatorcomment>Salvare CSV</translatorcomment>
         <translation></translation>
     </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="25"/>
+        <source>Export &amp;JSON ..</source>
+        <translation>Esportazione &amp;JSON ..</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Save JSON</source>
+        <translation>Salvare JSON</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Java Script Object Notation (*.json)</source>
+        <translation>Java Script Object Notation (*.json)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/openhantek/translations/openhantek_pl.ts
+++ b/openhantek/translations/openhantek_pl.ts
@@ -838,6 +838,21 @@
         <source>MATH</source>
         <translation type="vanished">MATH</translation>
     </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="25"/>
+        <source>Export &amp;JSON ..</source>
+        <translation>Eksportuj &amp;JSON ..</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Save JSON</source>
+        <translation>Zapisz JSON</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Java Script Object Notation (*.json)</source>
+        <translation>Java Script Object Notation (*.json)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -1526,7 +1541,7 @@
     </message>
     <message>
         <source>Demo mode without scope HW</source>
-        <translation type="vanished">Tryb demo bez hardware'u</translation>
+        <translation type="vanished">Tryb demo bez hardware&apos;u</translation>
     </message>
     <message>
         <source>Use OpenGL ES instead of OpenGL</source>

--- a/openhantek/translations/openhantek_pt.ts
+++ b/openhantek/translations/openhantek_pt.ts
@@ -812,6 +812,21 @@
         <source>MATH</source>
         <translation type="vanished">MATH</translation>
     </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="25"/>
+        <source>Export &amp;JSON ..</source>
+        <translation>Exportar &amp;JSON ..</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Save JSON</source>
+        <translation>Salvar JSON</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Java Script Object Notation (*.json)</source>
+        <translation>Java Script Object Notation (*.json)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/openhantek/translations/openhantek_ru.ts
+++ b/openhantek/translations/openhantek_ru.ts
@@ -680,6 +680,21 @@
         <source>Save CSV</source>
         <translation>Сохранить CSV</translation>
     </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="25"/>
+        <source>Export &amp;JSON ..</source>
+        <translation>Экспорт &amp;JSON ..</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Save JSON</source>
+        <translation>Сохранить JSON</translation>
+    </message>
+    <message>
+        <location filename="../src/exporting/exportjson.cpp" line="35"/>
+        <source>Java Script Object Notation (*.json)</source>
+        <translation>Java Script Object Notation (*.json)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>


### PR DESCRIPTION
JSON file support, compatible with RFC 8259 standard.
Translated in all languages.

Due to possible code duplication issues, CSV exporter was a bit refactored.
I moved out logic which is preparing output-ready data from `CSVExporter` to `ExporterData` and used this in `JSONExporter`

Please, tell me what you think about it.

<img src="https://user-images.githubusercontent.com/32263891/115124626-6bbe3a00-9fc3-11eb-902f-59ae417678a8.png" width="300px" height="auto" />
<img src="https://user-images.githubusercontent.com/32263891/115124722-00289c80-9fc4-11eb-821e-fb64aa13fee7.png" width="350px" height="auto" />
