### PR TITLE
Quick Screenshot/Hardcopy & tooltip

### DIFF
--- a/openhantek/src/mainwindow.cpp
+++ b/openhantek/src/mainwindow.cpp
@@ -101,13 +101,13 @@ MainWindow::MainWindow( HantekDsoControl *dsoControl, DsoSettings *settings, Exp
     setDockOptions( dockOptions() | QMainWindow::GroupedDragging );
 #endif
     QAction *action;
-    action = new QAction( iconFont->icon( fa::camera, colorMap ), tr( "Screenshot" ), this );
-    action->setToolTip( "Make an immediate screenshot of the program window" );
+    action = new QAction( iconFont->icon( fa::camera, colorMap ), tr( "Quick Screenshot" ), this );
+    action->setToolTip( "Save an immediate screenshot of the program window to directory OpenHantek was run from" );
     connect( action, &QAction::triggered, [ this ]() { screenShot( SCREENSHOT, true ); } );
     ui->menuExport->addAction( action );
 
-    action = new QAction( iconFont->icon( fa::clone, colorMap ), tr( "Hardcopy" ), this );
-    action->setToolTip( "Make an immediate (printable) hardcopy of the display" );
+    action = new QAction( iconFont->icon( fa::clone, colorMap ), tr( "Quick Hardcopy" ), this );
+    action->setToolTip( "Save an immediate (printable) hardcopy of the display to directory OpenHantek was run from" );
     connect( action, &QAction::triggered, [ this ]() {
         dsoWidget->switchToPrintColors();
         QTimer::singleShot( 20, [ this ]() { screenShot( HARDCOPY, true ); } );
@@ -117,12 +117,12 @@ MainWindow::MainWindow( HantekDsoControl *dsoControl, DsoSettings *settings, Exp
     ui->menuExport->addSeparator();
 
     action = new QAction( iconFont->icon( fa::camera, colorMap ), tr( "Screenshot .." ), this );
-    action->setToolTip( "Make a screenshot of the program window" );
+    action->setToolTip( "Save a screenshot of the program window" );
     connect( action, &QAction::triggered, [ this ]() { screenShot( SCREENSHOT ); } );
     ui->menuExport->addAction( action );
 
     action = new QAction( iconFont->icon( fa::clone, colorMap ), tr( "Hardcopy .." ), this );
-    action->setToolTip( "Make a (printable) hardcopy of the display" );
+    action->setToolTip( "Save a (printable) hardcopy of the display" );
     connect( action, &QAction::triggered, [ this ]() {
         dsoWidget->switchToPrintColors();
         QTimer::singleShot( 20, [ this ]() { screenShot( HARDCOPY ); } );

--- a/openhantek/translations/openhantek_de.ts
+++ b/openhantek/translations/openhantek_de.ts
@@ -1174,9 +1174,8 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="104"/>
         <source>Screenshot</source>
-        <translation>Screenshot</translation>
+        <translation type="vanished">Screenshot</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="119"/>
@@ -1184,9 +1183,8 @@
         <translation>Screenshot ..</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
         <source>Hardcopy</source>
-        <translation>Hardcopy</translation>
+        <translation type="vanished">Hardcopy</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="124"/>
@@ -1222,6 +1220,16 @@
     <message>
         <source>Settings (*.ini)</source>
         <translation type="vanished">Einstellungen (*.ini)</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="104"/>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="364"/>

--- a/openhantek/translations/openhantek_es.ts
+++ b/openhantek/translations/openhantek_es.ts
@@ -1044,9 +1044,8 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="104"/>
         <source>Screenshot</source>
-        <translation>Captura de pantalla</translation>
+        <translation type="vanished">Captura de pantalla</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="119"/>
@@ -1054,9 +1053,18 @@
         <translation>Captura de pantalla ..</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
         <source>Hardcopy</source>
-        <translation>Hardcopy</translation>
+        <translation type="vanished">Hardcopy</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="104"/>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="124"/>

--- a/openhantek/translations/openhantek_fr.ts
+++ b/openhantek/translations/openhantek_fr.ts
@@ -1119,9 +1119,8 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="104"/>
         <source>Screenshot</source>
-        <translation>Capture d&apos;écran</translation>
+        <translation type="vanished">Capture d&apos;écran</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="119"/>
@@ -1129,9 +1128,18 @@
         <translation>Capture d&apos;écran ..</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
         <source>Hardcopy</source>
-        <translation>Copie papier</translation>
+        <translation type="vanished">Copie papier</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="104"/>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="124"/>

--- a/openhantek/translations/openhantek_it.ts
+++ b/openhantek/translations/openhantek_it.ts
@@ -837,17 +837,17 @@
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="104"/>
-        <source>Screenshot</source>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="119"/>
         <source>Screenshot ..</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
-        <source>Hardcopy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/openhantek/translations/openhantek_pl.ts
+++ b/openhantek/translations/openhantek_pl.ts
@@ -1166,9 +1166,8 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="104"/>
         <source>Screenshot</source>
-        <translation>Zrzut ekranu</translation>
+        <translation type="vanished">Zrzut ekranu</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="119"/>
@@ -1176,9 +1175,8 @@
         <translation>Zrzut ekranu ..</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
         <source>Hardcopy</source>
-        <translation>Wydruk</translation>
+        <translation type="vanished">Wydruk</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="124"/>
@@ -1214,6 +1212,16 @@
     <message>
         <source>Settings (*.ini)</source>
         <translation type="vanished">Ustawienia (*.ini)</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="104"/>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="364"/>

--- a/openhantek/translations/openhantek_pt.ts
+++ b/openhantek/translations/openhantek_pt.ts
@@ -1070,8 +1070,13 @@
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="104"/>
-        <source>Screenshot</source>
-        <translation></translation>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="207"/>
@@ -1094,11 +1099,6 @@
     <message>
         <location filename="../src/mainwindow.cpp" line="119"/>
         <source>Screenshot ..</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
-        <source>Hardcopy</source>
         <translation></translation>
     </message>
     <message>

--- a/openhantek/translations/openhantek_ru.ts
+++ b/openhantek/translations/openhantek_ru.ts
@@ -957,14 +957,12 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="104"/>
         <source>Screenshot</source>
-        <translation>Снимок экрана</translation>
+        <translation type="vanished">Снимок экрана</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
         <source>Hardcopy</source>
-        <translation>Хардкопия</translation>
+        <translation type="vanished">Хардкопия</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="124"/>
@@ -1005,6 +1003,16 @@
     <message>
         <source>Settings (*.ini)</source>
         <translation type="vanished">Настройки (*.ini)</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="104"/>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="364"/>

--- a/openhantek/translations/openhantek_sv.ts
+++ b/openhantek/translations/openhantek_sv.ts
@@ -799,14 +799,22 @@
         <translation>Demoläge</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="104"/>
         <source>Screenshot</source>
-        <translation>Skärmbild</translation>
+        <translation type="vanished">Skärmbild</translation>
+    </message>
+    <message>
+        <source>Hardcopy</source>
+        <translation type="vanished">Hårdkopia</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="104"/>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="109"/>
-        <source>Hardcopy</source>
-        <translation>Hårdkopia</translation>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="119"/>

--- a/openhantek/translations/openhantek_zh.ts
+++ b/openhantek/translations/openhantek_zh.ts
@@ -1071,9 +1071,8 @@
         <translation>OpenHantek6022 (%1) - </translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="104"/>
         <source>Screenshot</source>
-        <translation>截屏(当前窗口)</translation>
+        <translation type="vanished">截屏(当前窗口)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="207"/>
@@ -1099,9 +1098,8 @@
         <translation>截屏另存为(当前窗口) ..</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="109"/>
         <source>Hardcopy</source>
-        <translation>截屏(波形区域)</translation>
+        <translation type="vanished">截屏(波形区域)</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="124"/>
@@ -1142,6 +1140,16 @@
     <message>
         <source>Settings (*.ini)</source>
         <translation type="vanished">配置文件 (*.ini)</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="104"/>
+        <source>Quick Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="109"/>
+        <source>Quick Hardcopy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="364"/>


### PR DESCRIPTION
I *really* think "Screenshot" and "Hardcopy" should be named something like "Quick Screenshot" and "Quick Hardcopy", to better distingush from "Screenshot .." and "Hardcopy ..".

Also I think the tooltip should fully explain.  It took me a while to figure out *where* exactly these quick screenshots/hardcopies are saved...turns out at least on my arch linux kde machine that they appear in the particular directory I executed openhantek from.

Sorry I realizes this marks the Qt translations as out-of-date...

Signed-off-by: Eric Fontaine <ericfontainejazz@gmail.com>