### PR TITLE
Fix offset sign

### DIFF
--- a/openhantek/src/hantekdso/hantekdsocontrol.cpp
+++ b/openhantek/src/hantekdso/hantekdsocontrol.cpp
@@ -800,7 +800,7 @@ void HantekDsoControl::convertRawDataToSamples() {
                 liveOffset += sample;
             }
             // qDebug() << channel << offsetCorrection[ gainIndex ][ channel ];
-            sample -= offsetCorr;
+            sample += offsetCorr;
             sample *= gainCorr;
 
             result.data[ channel ][ index ] = sign * sample / voltageScale * gainCalibration * probeAttn;


### PR DESCRIPTION
When using calibrate_6022.py, the offset in the config file has the the opposite sign from the eeprom:

https://github.com/Ho-Ro/Hantek6022API/blob/01b82fd6a4bcb7bef5116a209e26206373521244/examples/calibrate_6022.py#L191

With this change I get much better agreement between the oscilloscope and the multimeter I calibrated it against.