### PR TITLE
Fixes #363, refs #365. Splitted HorizontalDock::timebaseChanged handler.

### DIFF
--- a/openhantek/src/mainwindow.cpp
+++ b/openhantek/src/mainwindow.cpp
@@ -286,8 +286,9 @@ MainWindow::MainWindow( HantekDsoControl *dsoControl, DsoSettings *settings, Exp
     connect( horizontalDock, &HorizontalDock::timebaseChanged, triggerDock, &TriggerDock::timebaseChanged );
     connect( horizontalDock, &HorizontalDock::timebaseChanged, dsoControl, [ dsoControl, this ]() {
         dsoControl->setRecordTime( dsoSettings->scope.horizontal.timebase * DIVS_TIME );
-        this->dsoWidget->updateTimebase( dsoSettings->scope.horizontal.timebase );
     } );
+    connect( horizontalDock, &HorizontalDock::timebaseChanged, this->dsoWidget,
+             [ this ]() { dsoWidget->updateTimebase( dsoSettings->scope.horizontal.timebase ); } );
     connect( spectrumDock, &SpectrumDock::frequencybaseChanged, this,
              [ this ]( double frequencybase ) { this->dsoWidget->updateFrequencybase( frequencybase ); } );
     connect( dsoControl, &HantekDsoControl::samplerateChanged, horizontalDock,


### PR DESCRIPTION
**Windows 11**-targeted fix as it probably works on other platforms.

Splitted `HorizontalDock::timebaseChanged` event handler from doing operations on `dsoControl` and `dsoWidget` in the same callback. Now there are two callback and each uses the `QWidget` it operates on.

Now we can change horizontal time-base:

![image](https://github.com/OpenHantek/OpenHantek6022/assets/1587690/9c286bc8-c90b-427c-bedc-5c0925bf8b86)

![image](https://github.com/OpenHantek/OpenHantek6022/assets/1587690/77a837b4-8907-4ca9-a826-e2f046c39180)

![image](https://github.com/OpenHantek/OpenHantek6022/assets/1587690/061c3435-7127-43e5-bee4-096479bf575e)

Without the fix we encounter such issue:

![image](https://github.com/OpenHantek/OpenHantek6022/assets/1587690/d156ab53-e9e5-480e-8b5f-4d1c59ba4c3f)
