### PR TITLE
Adding Font Weight option

### DIFF
--- a/openhantek/src/main.cpp
+++ b/openhantek/src/main.cpp
@@ -92,12 +92,13 @@ int main( int argc, char *argv[] ) {
     bool useLocale = true;       // the command line option
     bool doNotTranslate = false; // the persistent option
     bool resetSettings = false;
-    QString font = defaultFont;       // defined in viewsettings.h
-    int fontSize = defaultFontSize;   // defined in viewsettings.h
-    int condensed = defaultCondensed; // defined in viewsettings.h
-    int theme = 0;                    // set to "auto"
-    int toolTipVisible = 1;           // start with tooltips
-    bool styleFusion = false;         // use system style
+    QString font = defaultFont;         // defined in viewsettings.h
+    int fontSize = defaultFontSize;     // defined in viewsettings.h
+    int fontWeight = defaultFontWeight; // defined in viewsettings.h
+    int condensed = defaultCondensed;   // defined in viewsettings.h
+    int theme = 0;                      // set to "auto"
+    int toolTipVisible = 1;             // start with tooltips
+    bool styleFusion = false;           // use system style
     QString configFileName = QString();
 
     { // do this early at program start ...
@@ -110,6 +111,7 @@ int main( int argc, char *argv[] ) {
         QSettings storeSettings;
         storeSettings.beginGroup( "view" );
         fontSize = storeSettings.value( "fontSize", defaultFontSize ).toInt();
+        fontWeight = storeSettings.value( "fontWeight", defaultFontWeight ).toInt();
         styleFusion = storeSettings.value( "styleFusion", false ).toBool();
         theme = storeSettings.value( "theme", 0 ).toInt();
         toolTipVisible = storeSettings.value( "toolTipVisible", 1 ).toInt();
@@ -172,6 +174,12 @@ int main( int argc, char *argv[] ) {
                 .arg( fontSize ),
             QCoreApplication::translate( "main", "Size" ) );
         p.addOption( sizeOption );
+        QCommandLineOption weightOption(
+            { "w", "weight" },
+            QString( QCoreApplication::translate( "main", "Set the font weight (default = %1)" ) )
+                .arg( fontWeight ),
+            QCoreApplication::translate( "main", "Weight" ) );
+        p.addOption( weightOption );
         QCommandLineOption condensedOption(
             "condensed", QCoreApplication::translate( "main", "Set the font condensed value (default = %1)" ).arg( condensed ),
             QCoreApplication::translate( "main", "Condensed" ) );
@@ -192,6 +200,8 @@ int main( int argc, char *argv[] ) {
             font = p.value( "font" );
         if ( p.isSet( sizeOption ) )
             fontSize = p.value( "size" ).toInt();
+        if ( p.isSet( weightOption ) )
+            fontWeight = p.value( "weight" ).toInt();
         if ( p.isSet( condensedOption ) ) // allow range from UltraCondensed (50) to UltraExpanded (200)
             condensed = qBound( 50, p.value( "condensed" ).toInt(), 200 );
         useGLES = p.isSet( useGlesOption );
@@ -483,6 +493,7 @@ int main( int argc, char *argv[] ) {
     appFont.setFamily( font ); // Fusion (or Windows) style + Arial (default) -> fit on small screen (Y >= 720)
     appFont.setStretch( condensed );
     appFont.setPointSize( fontSize ); // scales the widgets accordingly
+    appFont.setWeight( (QFont::Weight)fontWeight );
     // apply new font settings for the scope application
     if ( verboseLevel )
         qDebug() << startupTime.elapsed() << "ms:"

--- a/openhantek/src/viewsettings.h
+++ b/openhantek/src/viewsettings.h
@@ -13,6 +13,7 @@
 // These values allow a quite narrow but readable display
 const QString defaultFont = "Arial";
 const int defaultFontSize = 10;
+const int defaultFontWeight = 800; // ExtraBold
 const int defaultCondensed = 87; // SemiCondensed = 87%
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hello, this PR adds Font Weight option (used 'size' as template).
The value range is 0..1000 and is the 'int' representation of QFont::Weight enum.
I'm using normally mono-spaced font and with this option everything looks nice :).
Tested under Linux (Fedora 42 64-bit) and macOS.

![comit](https://github.com/user-attachments/assets/5215bf9a-7238-4289-8f97-248874a6bf72)
