### PR TITLE
Add RP2040 device support

### DIFF
--- a/openhantek/src/hantekdso/models/RP2040_0_calibration.ini
+++ b/openhantek/src/hantekdso/models/RP2040_0_calibration.ini
@@ -1,0 +1,50 @@
+; OpenHantek calibration file
+; individual calibration values for RP2040 without esternal circuit
+; copy into ~/.config/OpenHantek
+; will be read by .../src/hantekdso/modelRP2040.cpp
+
+; multiply channel to get the correct gain
+[gain]
+
+ch0\10mV=0.33
+ch0\20mV=0.33
+ch0\50mV=0.33
+ch0\100mV=0.33
+ch0\200mV=0.33
+ch0\500mV=0.33
+ch0\1000mV=0.33
+ch0\2000mV=0.33
+ch0\5000mV=0.33
+
+ch1\10mV=0.33
+ch1\20mV=0.33
+ch1\50mV=0.33
+ch1\100mV=0.33
+ch1\200mV=0.33
+ch1\500mV=0.33
+ch1\1000mV=0.33
+ch1\2000mV=0.33
+ch1\5000mV=0.33
+
+; add offset values
+[offset]
+
+ch0\10mV=-127
+ch0\20mV=-127
+ch0\50mV=-127
+ch0\100mV=-127
+ch0\200mV=-127
+ch0\500mV=-127
+ch0\1000mV=-127
+ch0\2000mV=-127
+ch0\5000mV=-127
+
+ch1\10mV=-127
+ch1\20mV=-127
+ch1\50mV=-127
+ch1\100mV=-127
+ch1\200mV=-127
+ch1\500mV=-127
+ch1\1000mV=-127
+ch1\2000mV=-127
+ch1\5000mV=-127

--- a/openhantek/src/hantekdso/models/modelRP2040.cpp
+++ b/openhantek/src/hantekdso/models/modelRP2040.cpp
@@ -88,8 +88,7 @@ static void applyRequirements_( HantekDsoControl *dsoControl ) {
 
 ///                                        VID/PID active  VID/PID no FW         Scope name
 //                                         |------------|  |------------|         |------|
-ModelRP2040::ModelRP2040()
-    : DSOModel( ID, 0x04b5, 0x2040, 0x04b5, 0x2040, 0, "", "RP2040", Dso::ControlSpecification( 2 ) ) {
+ModelRP2040::ModelRP2040() : DSOModel( ID, 0x2e8a, 0x2041, 0x2e8a, 0x2041, 0, "", "RP2040", Dso::ControlSpecification( 2 ) ) {
     initSpecifications( specification );
 }
 

--- a/openhantek/src/hantekdso/models/modelRP2040.cpp
+++ b/openhantek/src/hantekdso/models/modelRP2040.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "modelRP2040.h"
+#include "hantekdsocontrol.h"
+#include "hantekprotocol/controlStructs.h"
+#include "usb/scopedevice.h"
+#include <QDebug>
+#include <QDir>
+#include <QSettings>
+
+
+#define VERBOSE 0
+
+using namespace Hantek;
+
+static ModelRP2040 modelInstance_rp2040;
+
+static void initSpecifications( Dso::ControlSpecification &specification ) {
+    // we drop 2K + 480 sample values due to unreliable start of stream
+    // 20000 samples at 100kS/s = 200 ms gives enough to fill
+    // the screen two times (for pre/post trigger) at 10ms/div = 100ms/screen
+    // SAMPLESIZE defined in hantekdsocontrol.h
+    // adapt accordingly in HantekDsoControl::convertRawDataToSamples()
+
+    // HW gain, voltage steps in V/div (ranges 20,50,100,200,500,1000,2000,5000 mV)
+    specification.gain = { { 10, 20e-3 }, { 10, 50e-3 }, { 10, 100e-3 }, { 5, 200e-3 },
+                           { 2, 500e-3 }, { 1, 1.00 },   { 1, 2.00 },    { 1, 5.00 } };
+
+    // Define the scaling between ADC sample values and real input voltage
+    // Everything is scaled on the full screen height (8 divs)
+    // The voltage/div setting:      20m   50m  100m  200m  500m    1V    2V    5V
+    // Equivalent input voltage:   0.16V  0.4V  0.8V  1.6V    4V    8V   16V   40V
+    // Theoretical gain setting:     x10   x10   x10   x5    x2     x1    x1    x1
+    // mV / digit:                     4     4     4     8    20    40    40    40
+    // specification.voltageScale[ 0 ] = { 255, 255, 255, 127.5, 51, 25.5, 25.5, 25.5 };
+    // specification.voltageScale[ 1 ] = { 255, 255, 255, 127.5, 51, 25.5, 25.5, 25.5 };
+    specification.voltageScale[ 0 ] = { 250, 250, 250, 125, 50, 25, 25, 25 };
+    specification.voltageScale[ 1 ] = { 250, 250, 250, 125, 50, 25, 25, 25 };
+    // Gain and offset can be corrected by individual config values from EEPROM or file
+    // Lower effective sample rates < 10 kS/s use oversampling to increase the SNR
+
+    specification.samplerate.single.base = 100e3;
+    specification.samplerate.single.max = 1e6;
+    specification.samplerate.single.recordLengths = { UINT_MAX };
+    specification.samplerate.multi.base = 100e3;
+    specification.samplerate.multi.max = 1e6;
+    specification.samplerate.multi.recordLengths = { UINT_MAX };
+
+    specification.fixedSampleRates = {
+        // samplerate, sampleId, downsampling
+        { 1e3, 101, 10 },
+        { 2e3, 102, 10 },
+        { 5e3, 105, 10 },
+        { 10e3, 101, 1 },
+        { 20e3, 102, 1 },
+        { 50e3, 105, 1 },
+        { 100e3, 110, 1 },
+        { 200e3, 120, 1 },
+        { 500e3, 150, 1 },
+        { 1e6, 1, 1 }
+    };
+
+    specification.couplings = { Dso::Coupling::DC, Dso::Coupling::AC };
+    specification.triggerModes = {
+        Dso::TriggerMode::AUTO,
+        Dso::TriggerMode::NORMAL,
+        Dso::TriggerMode::SINGLE,
+        Dso::TriggerMode::ROLL,
+    };
+
+    specification.fixedUSBinLength = 0;
+
+    specification.calfreqSteps = { 30,   40,   50,   60,   80,   100,  120,  160,  200,  250,  300,  400,  440,
+                                   500,  600,  660,  800,  1000, 1200, 1600, 2000, 2500, 3300, 4000, 5000, 6000,
+                                   8000, 10e3, 12e3, 16e3, 20e3, 25e3, 30e3, 40e3, 50e3, 60e3, 80e3, 100e3 };
+    specification.hasCalibrationEEPROM = false;
+}
+
+static void applyRequirements_( HantekDsoControl *dsoControl ) {
+    dsoControl->addCommand( new ControlSetGain_CH1() );    // 0xE0
+    dsoControl->addCommand( new ControlSetGain_CH2() );    // 0xE1
+    dsoControl->addCommand( new ControlSetSamplerate() );  // 0xE2
+    dsoControl->addCommand( new ControlStartSampling() );  // 0xE3
+    dsoControl->addCommand( new ControlSetNumChannels() ); // 0xE4
+    dsoControl->addCommand( new ControlSetCoupling() );    // 0xE5 (no effect w/o AC/DC HW mod)
+    dsoControl->addCommand( new ControlSetCalFreq() );     // 0xE6
+}
+
+///                                        VID/PID active  VID/PID no FW         Scope name
+//                                         |------------|  |------------|         |------|
+ModelRP2040::ModelRP2040()
+    : DSOModel( ID, 0x04b5, 0x2040, 0x04b5, 0x2040, 0, "", "RP2040", Dso::ControlSpecification( 2 ) ) {
+    initSpecifications( specification );
+}
+
+void ModelRP2040::applyRequirements( HantekDsoControl *dsoControl ) const { applyRequirements_( dsoControl ); }
+
+

--- a/openhantek/src/hantekdso/models/modelRP2040.h
+++ b/openhantek/src/hantekdso/models/modelRP2040.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "dsomodel.h"
+
+class HantekDsoControl;
+using namespace Hantek;
+
+
+struct ModelRP2040 : public DSOModel {
+    static const int ID = 0x2040;
+    ModelRP2040();
+    void applyRequirements( HantekDsoControl *dsoControl ) const override;
+};
+

--- a/openhantek/src/usb/scopedevice.cpp
+++ b/openhantek/src/usb/scopedevice.cpp
@@ -77,6 +77,7 @@ bool ScopeDevice::connectDevice( QString &errorMessage ) {
         handle = nullptr;
         errorMessage =
             QCoreApplication::translate( "ScopeDevice", "Couldn't open device: %1" ).arg( libUsbErrorString( errorCode ) );
+            qDebug() << "  Couldn't open device: " << libUsbErrorString( errorCode );
         return false;
     }
     serialNumber = readUSBdescriptor( handle, descriptor.iSerialNumber );

--- a/utils/devd_rules_freebsd/openhantek.conf
+++ b/utils/devd_rules_freebsd/openhantek.conf
@@ -78,3 +78,15 @@ notify 100 {
     match "product" "0x0120";
     action "chgrp openhantek /dev/$ugen; chmod g+rw /dev/$ugen; chgrp -h openhantek /dev/$ugen; chmod -h g+rw /dev/$ugen";
 };
+
+
+# RP2040 with FW
+
+notify 100 {
+    match "system" "USB";
+    match "subsystem" "DEVICE";
+    match "type" "ATTACH";
+    match "vendor" "0x04B5";
+    match "product" "0x2040";
+    action "chgrp openhantek /dev/$ugen; chmod g+rw /dev/$ugen; chgrp -h openhantek /dev/$ugen; chmod -h g+rw /dev/$ugen";
+};

--- a/utils/udev_rules/60-openhantek.rules
+++ b/utils/udev_rules/60-openhantek.rules
@@ -31,4 +31,7 @@ ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="6021", TAG+="uaccess", TAG+="udev-ac
 ATTRS{idVendor}=="d4a2", ATTRS{idProduct}=="5660", TAG+="uaccess", TAG+="udev-acl", MODE="660", GROUP="plugdev"
 ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="608e", TAG+="uaccess", TAG+="udev-acl", MODE="660", GROUP="plugdev"
 
+# RP2040 with FW
+ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="2040", TAG+="uaccess", TAG+="udev-acl", MODE="660", GROUP="plugdev"
+
 LABEL="openhantek_rules_end"


### PR DESCRIPTION
Add RP2040 oscilloscope device support

This PR adds support in OpenHantek for an RP2040-based oscilloscope implementing the OpenHantek6022 protocol.

Firmware repository:
https://github.com/dgatf/oscilloscope_rp2040

Included changes:
- new RP2040 device model
- RP2040 calibration file
- device detection / USB handling updates
- udev and devd rule updates

The firmware provides a 2-channel oscilloscope compatible with the OpenHantek protocol.
In current testing, capture is reliable at 500 kS/s. Higher nominal sampling rates are available, but may drop samples depending on the configuration and USB transfer limits.

This PR only contains the OpenHantek-side changes required for RP2040 device support.